### PR TITLE
test: remove ai index re-export test

### DIFF
--- a/packages/core/tests/ai/generate.test.ts
+++ b/packages/core/tests/ai/generate.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AnyFn = (...args: any[]) => any;
+
+const aiNamespaceMock = { __esModule: true, default: { name: 'ai-namespace' } } as Record<string, unknown>;
+const generateTextMock = vi.fn<AnyFn>();
+const wrapAISDKMock = vi.fn<AnyFn>();
+const getModelMock = vi.fn<AnyFn>();
+
+vi.mock('ai', () => aiNamespaceMock);
+vi.mock('langsmith/experimental/vercel', () => ({
+  wrapAISDK: wrapAISDKMock,
+}));
+vi.mock('../../src/ai/models', () => ({
+  getModel: getModelMock,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  generateTextMock.mockReset();
+  wrapAISDKMock.mockReset();
+  wrapAISDKMock.mockImplementation(() => ({ generateText: generateTextMock }));
+  getModelMock.mockReset();
+});
+
+describe('generate', () => {
+  const importModule = () => import('@letsrunit/core/ai/generate');
+
+  it('uses the medium model by default', async () => {
+    const mediumModel = Symbol('medium');
+    getModelMock.mockReturnValue(mediumModel);
+    generateTextMock.mockResolvedValue({ text: 'generated text' });
+
+    const { generate } = await importModule();
+    const result = await generate('system message', 'prompt text');
+
+    expect(getModelMock).toHaveBeenCalledWith(undefined);
+    expect(generateTextMock).toHaveBeenCalledWith({
+      model: mediumModel,
+      system: 'system message',
+      prompt: 'prompt text',
+    });
+    expect(result).toBe('generated text');
+  });
+
+  it('allows overriding the selected model', async () => {
+    const largeModel = Symbol('large');
+    getModelMock.mockReturnValue(largeModel);
+    generateTextMock.mockResolvedValue({ text: 'large model output' });
+
+    const { generate } = await importModule();
+    const result = await generate('system', 'prompt', { model: 'large' });
+
+    expect(getModelMock).toHaveBeenCalledWith('large');
+    expect(generateTextMock).toHaveBeenCalledWith({
+      model: largeModel,
+      system: 'system',
+      prompt: 'prompt',
+    });
+    expect(result).toBe('large model output');
+  });
+
+  it('wraps the AI SDK using the langsmith adapter', async () => {
+    getModelMock.mockReturnValue(Symbol('model'));
+    generateTextMock.mockResolvedValue({ text: 'text' });
+
+    await importModule();
+
+    expect(wrapAISDKMock).toHaveBeenCalledTimes(1);
+    expect(wrapAISDKMock).toHaveBeenCalledWith(aiNamespaceMock);
+  });
+});

--- a/packages/core/tests/ai/models.test.ts
+++ b/packages/core/tests/ai/models.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type OpenAIImplementation = (name: string) => unknown;
+
+const openaiMock = vi.fn<OpenAIImplementation>();
+
+vi.mock('@ai-sdk/openai', () => ({
+  openai: openaiMock,
+}));
+
+describe('getModel', () => {
+  const importModule = () => import('@letsrunit/core/ai/models');
+
+  beforeEach(() => {
+    vi.resetModules();
+    openaiMock.mockReset();
+    openaiMock.mockImplementation((name) => ({ id: name }));
+  });
+
+  it('initializes the available models using the OpenAI factory', async () => {
+    await importModule();
+
+    expect(openaiMock).toHaveBeenCalledTimes(3);
+    expect(openaiMock.mock.calls).toEqual([
+      ['gpt-5'],
+      ['gpt-5-mini'],
+      ['gpt-5-nano'],
+    ]);
+  });
+
+  it('returns the correct model instance for every size and default parameter', async () => {
+    const module = await importModule();
+    const { getModel } = module;
+    const [largeModel, mediumModel, smallModel] = openaiMock.mock.results.map((result) => result.value);
+
+    expect(getModel('large')).toBe(largeModel);
+    expect(getModel('medium')).toBe(mediumModel);
+    expect(getModel('small')).toBe(smallModel);
+    expect(getModel()).toBe(mediumModel);
+  });
+});

--- a/packages/core/tests/ai/translate.test.ts
+++ b/packages/core/tests/ai/translate.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hash } from '@letsrunit/core/utils';
+
+type AnyFn = (...args: any[]) => any;
+
+const generateMock = vi.fn<AnyFn>();
+
+vi.mock('../../src/ai/generate', () => ({
+  generate: generateMock,
+}));
+
+describe('translate', () => {
+  const importModule = () => import('@letsrunit/core/ai/translate');
+
+  beforeEach(() => {
+    vi.resetModules();
+    generateMock.mockReset();
+  });
+
+  it('returns the original input when the language resolves to English', async () => {
+    const { translate } = await importModule();
+    const input = { greeting: 'Hello' } as const;
+
+    const result = await translate(input, 'en_US');
+
+    expect(result).toBe(input);
+    expect(generateMock).not.toHaveBeenCalled();
+  });
+
+  it('translates string inputs and caches the generated value', async () => {
+    const { translate } = await importModule();
+    const cacheKey = `${hash('Hello world')}:en:fr`;
+    const cache = {
+      get: vi.fn().mockResolvedValueOnce(undefined),
+      set: vi.fn(),
+      has: vi.fn(),
+    };
+    generateMock.mockResolvedValue('Bonjour le monde');
+
+    const result = await translate('Hello world', 'fr_FR', { cache });
+
+    expect(cache.get).toHaveBeenCalledWith(cacheKey);
+    expect(generateMock).toHaveBeenCalledWith(
+      'Translate the text from English to French.',
+      'Hello world',
+      { model: 'small' },
+    );
+    expect(cache.set).toHaveBeenCalledWith(cacheKey, 'Bonjour le monde');
+    expect(result).toBe('Bonjour le monde');
+  });
+
+  it('translates structured JSON with a custom prompt and fallback language name', async () => {
+    const { translate } = await importModule();
+    const input = { greeting: 'Hello', details: { count: 2 } } as const;
+    const jsonString = JSON.stringify(input, null, 2);
+    generateMock.mockResolvedValue('{"greeting":"Bonjour","details":{"count":2}}');
+
+    const result = await translate(input, 'xx_001', { prompt: 'Custom prompt for {lang}' });
+
+    expect(generateMock).toHaveBeenCalledWith('Custom prompt for xx', jsonString, { model: 'small' });
+    expect(result).toEqual({ greeting: 'Bonjour', details: { count: 2 } });
+    expect(result).not.toBe(input);
+  });
+
+  it('returns cached values without invoking the AI model', async () => {
+    const { translate } = await importModule();
+    const cacheKey = `${hash('Needs cache')}:en:es`;
+    const cache = {
+      get: vi.fn().mockResolvedValue('Desde caché'),
+      set: vi.fn(),
+      has: vi.fn(),
+    };
+
+    const result = await translate('Needs cache', 'es', { cache });
+
+    expect(cache.get).toHaveBeenCalledWith(cacheKey);
+    expect(generateMock).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(result).toBe('Desde caché');
+  });
+});


### PR DESCRIPTION
## Summary
- remove the AI index re-export test per updated requirements

## Testing
- yarn vitest --run --config packages/core/vitest.config.ts --environment jsdom --coverage *(fails: vitest dependency not present under PnP)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c415a1808320b38db4b8d6a258b9