### PR TITLE
Remove utils index export test

### DIFF
--- a/packages/core/tests/utils/hash.test.ts
+++ b/packages/core/tests/utils/hash.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { hash } from '../../src/utils/hash';
+
+describe('hash', () => {
+  it('creates the expected sha256 hash for a string', () => {
+    expect(hash('letsrunit')).toBe(
+      '0524dfe1cecbcb7b55ca6226cba336e846ce59d43a32a740db3492a8f7003832',
+    );
+  });
+
+  it('produces a consistent 64-character hash for identical input', () => {
+    const firstResult = hash('deterministic');
+    const secondResult = hash('deterministic');
+
+    expect(firstResult).toHaveLength(64);
+    expect(secondResult).toBe(firstResult);
+  });
+});

--- a/packages/core/tests/utils/sleep.test.ts
+++ b/packages/core/tests/utils/sleep.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { sleep } from '../../src/utils/sleep';
+
+describe('sleep', () => {
+  it('waits for the requested duration before resolving', async () => {
+    vi.useFakeTimers();
+
+    const sleepPromise = sleep(500);
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(sleepPromise).resolves.toBeUndefined();
+
+    vi.useRealTimers();
+  });
+
+  it('passes the delay to setTimeout', () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    sleep(1234);
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy.mock.calls[0]?.[1]).toBe(1234);
+
+    setTimeoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- remove the utils index test file since the module only re-exports other utilities

## Testing
- yarn vitest --run packages/core/tests/utils/hash.test.ts packages/core/tests/utils/sleep.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f2c4a1b8288320a0c30025fa32093d