### PR TITLE
Improve inverse icon test coverage

### DIFF
--- a/apps/web/src/components/inverse-icon/inverse-icon.test.tsx
+++ b/apps/web/src/components/inverse-icon/inverse-icon.test.tsx
@@ -4,9 +4,19 @@ import { render, screen } from '@testing-library/react';
 import { InverseIcon } from './inverse-icon';
 
 describe('InverseIcon', () => {
-  it('renders', () => {
-    render(<InverseIcon>Hello</InverseIcon>);
-    expect(screen.getByText(/InverseIcon/)).toBeInTheDocument();
-    expect(screen.getByText(/Hello/)).toBeInTheDocument();
+  it('renders the icon and overlay with sizing', () => {
+    const StubIcon = ({ size = 0 }: { size?: string | number }) => (
+      <svg data-testid="stub-icon" data-size={size} />
+    );
+
+    const { container } = render(<InverseIcon Icon={StubIcon} size={32} />);
+
+    expect(screen.getByTestId('stub-icon')).toHaveAttribute('data-size', '32');
+
+    const slashOverlay = container.querySelector('svg:not([data-testid="stub-icon"])');
+    expect(slashOverlay).not.toBeNull();
+    expect(slashOverlay).toHaveClass('absolute', 'inset-0');
+    expect(slashOverlay).toHaveAttribute('width', '32');
+    expect(slashOverlay).toHaveAttribute('height', '32');
   });
 });


### PR DESCRIPTION
## Summary
- update InverseIcon test to render with a stub icon component
- verify the stub icon receives the size prop and the Slash overlay renders with expected sizing classes

## Testing
- yarn workspace web test inverse-icon.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7382bd50832097cdda4f0faf638f)