### PR TITLE
Improve screenshot placeholder tests

### DIFF
--- a/apps/web/src/components/screenshot/screenshot.test.tsx
+++ b/apps/web/src/components/screenshot/screenshot.test.tsx
@@ -4,9 +4,16 @@ import { render, screen } from '@testing-library/react';
 import { Screenshot } from './screenshot';
 
 describe('Screenshot', () => {
-  it('renders', () => {
-    render(<Screenshot>Hello</Screenshot>);
-    expect(screen.getByText(/Screenshot/)).toBeInTheDocument();
-    expect(screen.getByText(/Hello/)).toBeInTheDocument();
+  it('shows the image when src is provided', () => {
+    render(<Screenshot src="/demo.png" alt="Example screenshot" width={400} height={300} />);
+
+    expect(screen.getByAltText('Example screenshot')).toBeInTheDocument();
+  });
+
+  it('shows the placeholder when src is missing', () => {
+    const { container } = render(<Screenshot width={400} height={300} />);
+
+    expect(screen.getByText('No screenshot')).toBeInTheDocument();
+    expect(container.querySelector('.pi.pi-desktop')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update Screenshot component tests to cover image rendering when src is provided
- verify placeholder text and desktop icon appear when no src is supplied

## Testing
- yarn workspace web test src/components/screenshot/screenshot.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7384f7f88320aa8b9df0d6a3eb39)