### PR TITLE
Replace PrimeIcons with lucide icons

### DIFF
--- a/apps/web/src/app/page.module.css
+++ b/apps/web/src/app/page.module.css
@@ -136,7 +136,8 @@
 
 .cardIcon {
   display: block;
-  font-size: 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
   color: var(--primary-color);
   margin-bottom: 1.2rem;
   opacity: 0.95;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { ExploreForm } from '../components/explore-form';
 import { ScrollDownButton } from '../components/scroll-down-button';
 import { BackToTopButton } from '../components/back-to-top-button';
+import { ArrowUp, Lightbulb, ListChecks, Sitemap } from 'lucide-react';
 
 export default function Home() {
   return (
@@ -43,7 +44,7 @@ export default function Home() {
 
           <div className={styles.grid}>
             <div className={styles.card}>
-              <i className={`pi pi-sitemap ${styles.cardIcon}`} aria-hidden="true"></i>
+              <Sitemap className={styles.cardIcon} aria-hidden="true" />
               <h3>
                 E2E tests &mdash; generated<span>.</span>
               </h3>
@@ -53,7 +54,7 @@ export default function Home() {
               </p>
             </div>
             <div className={styles.card}>
-              <i className={`pi pi-list-check ${styles.cardIcon}`} aria-hidden="true"></i>
+              <ListChecks className={styles.cardIcon} aria-hidden="true" />
               <h3>
                 Reproduce &rarr; Report &rarr; Recover<span>.</span>
               </h3>
@@ -63,7 +64,7 @@ export default function Home() {
               </p>
             </div>
             <div className={styles.card}>
-              <i className={`pi pi-lightbulb ${styles.cardIcon}`} aria-hidden="true"></i>
+              <Lightbulb className={styles.cardIcon} aria-hidden="true" />
               <h3>
                 BDD clarity on red builds<span>.</span>
               </h3>
@@ -134,7 +135,7 @@ export default function Home() {
             <BackToTopButton
               ariaLabel="Back to top"
               label="Back to top"
-              icon="pi pi-arrow-up"
+              icon={<ArrowUp aria-hidden="true" />}
               className={styles.backTopBtn}
             />
           </div>

--- a/apps/web/src/components/back-to-top-button/back-to-top-button.tsx
+++ b/apps/web/src/components/back-to-top-button/back-to-top-button.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import React from "react";
+import { ArrowUp } from "lucide-react";
 import { Button } from "primereact/button";
 
 export type BackToTopButtonProps = {
   className?: string;
   label?: string;
   ariaLabel?: string;
-  icon?: string;
+  icon?: React.ReactNode;
 };
 
 function scrollTop() {
@@ -16,7 +17,12 @@ function scrollTop() {
   }
 }
 
-export function BackToTopButton({ className, label = "Back to top", ariaLabel = "Back to top", icon = "pi pi-arrow-up" }: BackToTopButtonProps) {
+export function BackToTopButton({
+  className,
+  label = "Back to top",
+  ariaLabel = "Back to top",
+  icon = <ArrowUp aria-hidden="true" />,
+}: BackToTopButtonProps) {
   return (
     <Button
       aria-label={ariaLabel}

--- a/apps/web/src/components/queue-status/queue-status.css
+++ b/apps/web/src/components/queue-status/queue-status.css
@@ -28,7 +28,8 @@
   border-color: #3f3f46; /* zinc-700 */
 }
 
-/* Make sure the PrimeIcon in the gradient tile remains visible */
-.queue-status-card .pi {
+.queue-status-icon {
+  width: 2rem;
+  height: 2rem;
   color: rgba(255, 255, 255, 0.8);
 }

--- a/apps/web/src/components/queue-status/queue-status.tsx
+++ b/apps/web/src/components/queue-status/queue-status.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'motion/react';
 import React from 'react';
 import { Card } from 'primereact/card';
+import { Settings } from 'lucide-react';
 import './queue-status.css';
 
 export function QueueStatus() {
@@ -40,7 +41,7 @@ export function QueueStatus() {
                 color: 'var(--primary-color-text)',
               }}
             >
-              <i className="pi pi-cog" style={{ fontSize: '2rem' }} aria-hidden="true" />
+              <Settings className="queue-status-icon" aria-hidden="true" />
             </div>
           </div>
 

--- a/apps/web/src/components/run-result/run-result.tsx
+++ b/apps/web/src/components/run-result/run-result.tsx
@@ -3,7 +3,7 @@
 import { RunTimeline, RunTimelineSkeleton } from '@/components/run-timeline';
 import { Screenshot } from '@/components/screenshot';
 import type { Artifact, Journal, Project, Run, RunStatus } from '@letsrunit/model';
-import { CheckCircle2, Clock, XCircle } from 'lucide-react';
+import { CheckCircle2, Clock, Globe2, XCircle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { BreadCrumb } from 'primereact/breadcrumb';
 import { Button } from 'primereact/button';
@@ -62,8 +62,8 @@ export function RunResult({ project, run, journal }: JournalProps) {
             <h1 className="m-0 text-base text-white font-normal">{runTitle?.message ?? run.target}</h1>
             {run && (
               <div className="flex align-items-baseline gap-3 mt-3 mb-2">
-                <div>
-                  <i className="pi pi-globe mr-1" /> Chrome 120
+                <div className="flex align-items-center gap-1">
+                  <Globe2 size={16} aria-hidden="true" /> <span>Chrome 120</span>
                 </div>
               </div>
             )}

--- a/apps/web/src/components/run-timeline/run-timeline.module.css
+++ b/apps/web/src/components/run-timeline/run-timeline.module.css
@@ -8,6 +8,11 @@
   height: 14px;
 }
 
+.statusIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
 .dot {
   display: inline-block;
   width: 0.5rem; /* 8px */

--- a/apps/web/src/components/run-timeline/run-timeline.tsx
+++ b/apps/web/src/components/run-timeline/run-timeline.tsx
@@ -6,6 +6,7 @@ import type { JournalEntry, RunStatus } from '@letsrunit/model';
 import { cn, join } from '@letsrunit/utils';
 import { Button } from 'primereact/button';
 import { useTimelinePlayer } from '@/hooks/use-timeline-player';
+import { CheckCircle2, Circle, CircleDot, Pause, Play, XCircle } from 'lucide-react';
 
 type StepStatus = 'passed' | 'failed' | 'pending';
 
@@ -69,20 +70,23 @@ function markerTemplate(item: ExtendedRunStep, status: RunStatus) {
       );
     }
     // Other pending steps – gray open circle
-    return <span className="pi pi-circle text-500" aria-label="pending" />;
+    return <Circle className={cn(styles.statusIcon, 'text-500')} aria-label="pending" />;
   }
 
   if (item.status === 'passed') {
     return (
-      <span
-        className={cn('pi', item.hasScreenshot ? 'pi-circle-fill' : 'pi-check-circle', styles.textGreen)}
-        aria-label="success"
-      />
+      <>
+        {item.hasScreenshot ? (
+          <CircleDot className={cn(styles.statusIcon, styles.textGreen)} aria-label="success" />
+        ) : (
+          <CheckCircle2 className={cn(styles.statusIcon, styles.textGreen)} aria-label="success" />
+        )}
+      </>
     );
   }
 
   // failed
-  return <span className={cn('pi', 'pi-times-circle', styles.textRed)} aria-label="failed" />;
+  return <XCircle className={cn(styles.statusIcon, styles.textRed)} aria-label="failed" />;
 }
 
 // Custom content template for Timeline
@@ -187,7 +191,7 @@ export function RunTimeline({ status, entries, onSelect }: RunTimelineProps) {
           {onSelect && status !== 'running' && (
             <Button
               outlined
-              icon={playing ? 'pi pi-pause' : 'pi pi-play'}
+              icon={playing ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
               aria-label={playing ? 'Pause' : 'Play'}
               onClick={toggle}
             />

--- a/apps/web/src/components/screenshot/screenshot.module.css
+++ b/apps/web/src/components/screenshot/screenshot.module.css
@@ -19,3 +19,10 @@
   min-height: 100%;
   display: flex;
 }
+
+.noImageIcon {
+  width: 2rem;
+  height: 2rem;
+  margin-bottom: 0.5rem;
+  color: var(--surface-400);
+}

--- a/apps/web/src/components/screenshot/screenshot.tsx
+++ b/apps/web/src/components/screenshot/screenshot.tsx
@@ -1,5 +1,6 @@
 import React, { type CSSProperties } from 'react';
 import Image from 'next/image';
+import { Monitor } from 'lucide-react';
 import styles from './screenshot.module.css';
 
 export type ScreenshotProps = {
@@ -16,7 +17,7 @@ export function Screenshot({ src, alt, style, width, height }: ScreenshotProps) 
       {src && <Image src={src} alt={alt ?? 'screenshot'} width={width} height={height} />}
       {!src && (
         <div className={styles.noImage}>
-          <i className="pi pi-desktop"></i>
+          <Monitor aria-hidden="true" className={styles.noImageIcon} />
           <div>No screenshot</div>
         </div>
       )}

--- a/apps/web/src/components/scroll-down-button/scroll-down-button.tsx
+++ b/apps/web/src/components/scroll-down-button/scroll-down-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { ChevronDown } from "lucide-react";
 import { Button } from "primereact/button";
 
 export type ScrollDownButtonProps = {
@@ -23,7 +24,7 @@ export function ScrollDownButton({ className, targetId = "learn-more", ariaLabel
   return (
     <Button
       aria-label={ariaLabel}
-      icon="pi pi-chevron-down"
+      icon={<ChevronDown aria-hidden="true" />}
       className={className}
       onClick={handleScrollDownClick}
       data-target-id={targetId}


### PR DESCRIPTION
## Summary
- replace PrimeIcons across the web workspace with lucide-react equivalents
- adjust component styling to fit inline lucide icons
- update timeline controls and buttons to render lucide icons directly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b77347508832090d59daab61ebbb8)