### PR TITLE
Add statusSymbol tests

### DIFF
--- a/packages/utils/tests/status-symbol.test.ts
+++ b/packages/utils/tests/status-symbol.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { statusSymbol } from '../src/status-symbol';
+
+describe('statusSymbol', () => {
+  it('returns check mark for success', () => {
+    expect(statusSymbol('success')).toBe('✓');
+  });
+
+  it('returns cross mark for failure', () => {
+    expect(statusSymbol('failure')).toBe('✘');
+  });
+
+  it('returns circle for undefined or unknown status', () => {
+    expect(statusSymbol()).toBe('○');
+    expect(statusSymbol('other')).toBe('○');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for statusSymbol covering success, failure, and fallback statuses

## Testing
- yarn workspace @letsrunit/utils test status-symbol.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f1e1e2b4832093b52a0f2c1ff22d)