### PR TITLE
test: mock @supabase/supabase-js in web Vitest setup

### DIFF
--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(),
+    storage: {},
+  })),
+}));


### PR DESCRIPTION
### Motivation
- Prevent Vite import failures when web tests load `@letsrunit/model` exports by providing a runtime mock of the Supabase client.

### Description
- Add a Vitest setup mock in `apps/web/test-setup.ts` that stubs `@supabase/supabase-js`'s `createClient` to return an object with `from` and `storage` methods.

### Testing
- No automated tests were run as part of this change; the update only modifies the Vitest setup file to avoid import errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea5f085548320ae1cb0af41dc567c)