### PR TITLE
Fix web action tests and align them with queueRun/feature flows

### DIFF
--- a/apps/web/src/actions/__tests__/create.test.ts
+++ b/apps/web/src/actions/__tests__/create.test.ts
@@ -1,9 +1,50 @@
-import { describe, expect, it } from 'vitest';
-import { createFeature } from '../create-feature';
+import { describe, expect, it, vi } from 'vitest';
+import { disableFeature, enableFeature } from '../features';
 
-describe('action create', () => {
-  it('returns ok: true', async () => {
-    const res = await createFeature();
-    expect(res).toEqual({ ok: true });
+vi.mock('@letsrunit/model', () => {
+  return {
+    updateFeature: vi.fn(),
+  };
+});
+
+vi.mock('@/libs/auth', () => {
+  return {
+    getUser: vi.fn().mockResolvedValue({ id: '11111111-1111-1111-1111-111111111111' }),
+  };
+});
+
+vi.mock('@/libs/supabase/server', () => {
+  return {
+    connect: vi.fn().mockResolvedValue({}),
+  };
+});
+
+describe('action features', () => {
+  it('enables a feature', async () => {
+    const { updateFeature } = await import('@letsrunit/model');
+
+    const featureId = '22222222-2222-2222-2222-222222222222' as any;
+
+    await enableFeature(featureId);
+
+    expect(updateFeature).toHaveBeenCalledWith(
+      featureId,
+      { enabled: true },
+      { by: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
+  });
+
+  it('disables a feature', async () => {
+    const { updateFeature } = await import('@letsrunit/model');
+
+    const featureId = '33333333-3333-3333-3333-333333333333' as any;
+
+    await disableFeature(featureId);
+
+    expect(updateFeature).toHaveBeenCalledWith(
+      featureId,
+      { enabled: false },
+      { by: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
   });
 });

--- a/apps/web/src/actions/__tests__/explore.test.ts
+++ b/apps/web/src/actions/__tests__/explore.test.ts
@@ -4,7 +4,6 @@ import { startExploreRun } from '../explore';
 vi.mock('@letsrunit/model', () => {
   return {
     createProject: vi.fn(),
-    createRun: vi.fn(),
   };
 });
 
@@ -14,13 +13,20 @@ vi.mock('@/libs/auth', () => {
   };
 });
 
+vi.mock('@/libs/run', () => {
+  return {
+    queueRun: vi.fn(),
+  };
+});
+
 describe('action explore', () => {
   it('creates project when not provided and then creates explore run (normalizes target)', async () => {
-    const { createProject, createRun } = await import('@letsrunit/model');
+    const { createProject } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
     const createdProjectId = '22222222-2222-2222-2222-222222222222';
     const runId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
     (createProject as any).mockResolvedValue(createdProjectId);
-    (createRun as any).mockResolvedValue(runId);
+    (queueRun as any).mockResolvedValue(runId);
 
     const result = await startExploreRun('site.test', { supabase: {} as any });
 
@@ -28,7 +34,7 @@ describe('action explore', () => {
       { url: 'https://site.test', accountId: '11111111-1111-1111-1111-111111111111' },
       { by: { id: '11111111-1111-1111-1111-111111111111' } },
     );
-    expect(createRun).toHaveBeenCalledWith(
+    expect(queueRun).toHaveBeenCalledWith(
       { type: 'explore', projectId: createdProjectId, target: 'https://site.test' },
       { by: { id: '11111111-1111-1111-1111-111111111111' } },
     );
@@ -36,16 +42,17 @@ describe('action explore', () => {
   });
 
   it('uses provided projectId and does not call createProject', async () => {
-    const { createProject, createRun } = await import('@letsrunit/model');
+    const { createProject } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
     const runId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
-    (createRun as any).mockResolvedValue(runId);
+    (queueRun as any).mockResolvedValue(runId);
     (createProject as any).mockReset();
 
     const projectId = '33333333-3333-3333-3333-333333333333' as any;
     const result = await startExploreRun('https://site.test', { supabase: {} as any, projectId });
 
     expect(createProject).not.toHaveBeenCalled();
-    expect(createRun).toHaveBeenCalledWith(
+    expect(queueRun).toHaveBeenCalledWith(
       { type: 'explore', projectId, target: 'https://site.test' },
       { by: { id: '11111111-1111-1111-1111-111111111111' } },
     );

--- a/apps/web/src/actions/__tests__/generate.test.ts
+++ b/apps/web/src/actions/__tests__/generate.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { startGenerateRun } from '../generate';
 
-// Mocks
 vi.mock('@letsrunit/model', () => {
   return {
-    createRun: vi.fn(),
+    createFeature: vi.fn(),
+    getFeatureTarget: vi.fn(),
   };
 });
 
@@ -14,17 +14,50 @@ vi.mock('@/libs/auth', () => {
   };
 });
 
+vi.mock('@/libs/run', () => {
+  return {
+    queueRun: vi.fn(),
+  };
+});
+
 describe('action generate', () => {
-  it('creates a generate run with the given featureId and returns runId', async () => {
-    const { createRun } = await import('@letsrunit/model');
+  it('creates a generate run for an existing featureId', async () => {
+    const { createFeature, getFeatureTarget } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
     const runId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-    (createRun as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(runId);
+    const target = 'https://site.test/feature';
+    (getFeatureTarget as any).mockResolvedValue(target);
+    (queueRun as any).mockResolvedValue(runId);
 
     const featureId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as any;
     const res = await startGenerateRun(featureId, { supabase: {} as any });
 
-    expect(createRun).toHaveBeenCalledWith(
-      { type: 'generate', featureId },
+    expect(createFeature).not.toHaveBeenCalled();
+    expect(getFeatureTarget).toHaveBeenCalledWith(featureId);
+    expect(queueRun).toHaveBeenCalledWith(
+      { type: 'generate', featureId, target },
+      { by: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
+    expect(res).toBe(runId);
+  });
+
+  it('creates a generate run for a new feature suggestion', async () => {
+    const { createFeature, getFeatureTarget } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
+    const runId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const featureId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const target = 'https://site.test/new';
+    (createFeature as any).mockResolvedValue(featureId);
+    (getFeatureTarget as any).mockResolvedValue(target);
+    (queueRun as any).mockResolvedValue(runId);
+
+    const suggestion = { projectId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee' } as any;
+    const res = await startGenerateRun(suggestion, { supabase: {} as any });
+
+    expect(createFeature).toHaveBeenCalledWith(suggestion, { by: { id: '11111111-1111-1111-1111-111111111111' } });
+    expect(getFeatureTarget).toHaveBeenCalledWith(featureId);
+    expect(queueRun).toHaveBeenCalledWith(
+      { type: 'generate', featureId, target },
       { by: { id: '11111111-1111-1111-1111-111111111111' } },
     );
     expect(res).toBe(runId);

--- a/apps/web/src/actions/__tests__/run.test.ts
+++ b/apps/web/src/actions/__tests__/run.test.ts
@@ -1,9 +1,65 @@
-import { describe, expect, it } from "vitest";
-import { run } from "../run";
+import { describe, expect, it, vi } from 'vitest';
+import { startTestRun } from '../run';
+
+vi.mock('@letsrunit/model', () => {
+  return {
+    createFeature: vi.fn(),
+    getFeatureTarget: vi.fn(),
+  };
+});
+
+vi.mock('@/libs/auth', () => {
+  return {
+    getUser: vi.fn().mockResolvedValue({ id: '11111111-1111-1111-1111-111111111111' }),
+  };
+});
+
+vi.mock('@/libs/run', () => {
+  return {
+    queueRun: vi.fn(),
+  };
+});
 
 describe('action run', () => {
-  it('returns ok: true', async () => {
-    const res = await run();
-    expect(res).toEqual({ ok: true });
+  it('creates a test run for an existing featureId', async () => {
+    const { createFeature, getFeatureTarget } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
+    const runId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const target = 'https://site.test/feature';
+    (getFeatureTarget as any).mockResolvedValue(target);
+    (queueRun as any).mockResolvedValue(runId);
+
+    const featureId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as any;
+    const res = await startTestRun(featureId, { supabase: {} as any });
+
+    expect(createFeature).not.toHaveBeenCalled();
+    expect(getFeatureTarget).toHaveBeenCalledWith(featureId);
+    expect(queueRun).toHaveBeenCalledWith(
+      { type: 'test', featureId, target },
+      { by: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
+    expect(res).toBe(runId);
+  });
+
+  it('creates a test run for a new feature suggestion', async () => {
+    const { createFeature, getFeatureTarget } = await import('@letsrunit/model');
+    const { queueRun } = await import('@/libs/run');
+    const runId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const featureId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const target = 'https://site.test/new';
+    (createFeature as any).mockResolvedValue(featureId);
+    (getFeatureTarget as any).mockResolvedValue(target);
+    (queueRun as any).mockResolvedValue(runId);
+
+    const suggestion = { projectId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee' } as any;
+    const res = await startTestRun(suggestion, { supabase: {} as any });
+
+    expect(createFeature).toHaveBeenCalledWith(suggestion, { by: { id: '11111111-1111-1111-1111-111111111111' } });
+    expect(getFeatureTarget).toHaveBeenCalledWith(featureId);
+    expect(queueRun).toHaveBeenCalledWith(
+      { type: 'test', featureId, target },
+      { by: { id: '11111111-1111-1111-1111-111111111111' } },
+    );
+    expect(res).toBe(runId);
   });
 });


### PR DESCRIPTION
### Motivation
- The `create.test.ts` referenced a non-resolving `create-feature` import and the action tests were out of sync with current action implementations that use `queueRun` and model feature APIs.
- Update tests to reflect actual action behavior and cover both existing feature and suggestion-based branches.

### Description
- Replaced the broken `create.test.ts` with tests for `enableFeature`/`disableFeature` that mock `@letsrunit/model`, `@/libs/auth`, and `@/libs/supabase/server`; file modified: `apps/web/src/actions/__tests__/create.test.ts`.
- Updated `explore` action tests to mock and assert `queueRun` instead of a non-existent `createRun`; file modified: `apps/web/src/actions/__tests__/explore.test.ts`.
- Updated `generate` and `run` action tests to mock `createFeature`, `getFeatureTarget`, and `queueRun`, and added coverage for suggestion-based feature creation branches; files modified: `apps/web/src/actions/__tests__/generate.test.ts` and `apps/web/src/actions/__tests__/run.test.ts`.
- Added necessary `vi.mock` calls and adjusted imports to use the actual exported action functions like `startGenerateRun` and `startTestRun` in tests.

### Testing
- Ran the workspace test command `yarn workspace web test` to exercise the updated action tests.
- The updated action tests (`explore`, `generate`, `run`, and `features` tests) execute and assert the `queueRun` / feature-target flows as expected.
- The full `web` test run still includes unrelated component test failures (existing UI/component tests), and the overall test run was interrupted after observing remaining unrelated failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea5ef35e08320995582f2086bfed9)