### PR TITLE
ci(init): fix mcp tarball smoke invocation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: yarn workspace letsrunit-docs build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: docusaurus/build
 

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -67,6 +67,8 @@ jobs:
   init:
     name: Init (${{ matrix.pm }})
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
     needs: build
     strategy:
       fail-fast: false
@@ -165,10 +167,6 @@ jobs:
             pnpm) pnpm install ;;
             bun)  bun install ;;
           esac
-
-      - name: Install Playwright system deps
-        working-directory: /tmp/test-${{ matrix.pm }}
-        run: node_modules/.bin/playwright install-deps chromium
 
       - name: Run init
         working-directory: /tmp/test-${{ matrix.pm }}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -88,11 +88,11 @@ jobs:
         with:
           version: latest
 
-      - name: Install unzip for Bun setup
+      - name: Install Bun prerequisites
         if: matrix.pm == 'bun'
         run: |
           apt-get update
-          apt-get install -y unzip
+          apt-get install -y unzip build-essential
 
       - uses: oven-sh/setup-bun@v2
         if: matrix.pm == 'bun'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -202,8 +202,7 @@ jobs:
         run: |
           set -euo pipefail
           npx -y @modelcontextprotocol/inspector --cli \
-            npx -y /tmp/mcp-server.tgz \
+            npx -y file:/tmp/mcp-server.tgz \
             --method tools/list > /tmp/mcp-tools.json
           jq -e '.tools | length > 0' /tmp/mcp-tools.json >/dev/null
           jq -e '.tools[] | select(.name == "letsrunit_session_start")' /tmp/mcp-tools.json >/dev/null
-

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -197,12 +197,33 @@ jobs:
           name: tarballs
           path: /tmp
 
-      - name: MCP handshake smoke (tools/list)
+      - name: MCP smoke (startup + tools/list)
         shell: bash
         run: |
           set -euo pipefail
-          npx -y @modelcontextprotocol/inspector --cli \
-            npx -y file:/tmp/mcp-server.tgz \
-            --method tools/list > /tmp/mcp-tools.json
+
+          cat >/tmp/run-mcp.sh <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec npx -y file:/tmp/mcp-server.tgz 2>/tmp/mcp-server.stderr
+          EOF
+          chmod +x /tmp/run-mcp.sh
+
+          set +e
+          timeout 5s /tmp/run-mcp.sh >/tmp/mcp-server.stdout
+          startup_rc=$?
+          set -e
+          if [ "$startup_rc" -ne 124 ]; then
+            echo "MCP server crashed on startup"
+            sed -n '1,200p' /tmp/mcp-server.stderr || true
+            exit 1
+          fi
+
+          if ! npx -y @modelcontextprotocol/inspector --cli /tmp/run-mcp.sh --method tools/list > /tmp/mcp-tools.json; then
+            echo "Inspector handshake failed"
+            sed -n '1,200p' /tmp/mcp-server.stderr || true
+            exit 1
+          fi
+
           jq -e '.tools | length > 0' /tmp/mcp-tools.json >/dev/null
           jq -e '.tools[] | select(.name == "letsrunit_session_start")' /tmp/mcp-tools.json >/dev/null

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -83,10 +83,16 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: matrix.pm == 'pnpm'
         with:
           version: latest
+
+      - name: Install unzip for Bun setup
+        if: matrix.pm == 'bun'
+        run: |
+          apt-get update
+          apt-get install -y unzip
 
       - uses: oven-sh/setup-bun@v2
         if: matrix.pm == 'bun'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -11,14 +11,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - name: Build monorepo
@@ -44,7 +44,7 @@ jobs:
           yarn workspace @letsrunit/store pack --out /tmp/store.tgz
           yarn workspace @letsrunit/utils pack --out /tmp/utils.tgz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: tarballs
           path: |
@@ -77,9 +77,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: pnpm/action-setup@v4
         if: matrix.pm == 'pnpm'
@@ -89,7 +89,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: matrix.pm == 'bun'
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: tarballs
           path: /tmp
@@ -192,7 +192,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - uses: actions/download-artifact@v7
         with:
           name: tarballs
           path: /tmp

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
           - "@letsrunit/ai"
           - "@letsrunit/mcp-server"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "yarn"
@@ -51,10 +51,10 @@ jobs:
         workspace:
           - "@letsrunit/compat-react"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "yarn"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
   compat:
     name: Test ${{ matrix.workspace }}
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +68,7 @@ jobs:
         run: yarn build:packages
 
       - name: Install Playwright Browsers
-        run: yarn workspace ${{ matrix.workspace }} playwright install --with-deps
+        run: yarn workspace ${{ matrix.workspace }} playwright install chromium
 
       - name: Run Tests
         run: yarn workspace ${{ matrix.workspace }} test


### PR DESCRIPTION
## Summary
- run MCP smoke against the packed tarball using a valid npm file spec
- change  to 

## Why
The previous command treated the tarball like an executable path, causing the MCP process to close before handshake. Using  makes npx install and execute the packaged CLI correctly.

## Validation
- inspected failing run logs from job 70424558710 in run 24136041308
- confirmed failure mode () maps to invalid tarball invocation format
