### PR TITLE
Only run tests on pull requests

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,8 +1,5 @@
 name: Init Integration Test
-
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
-name: Tests
+name: Unit Tests
 on:
   pull_request:
-    branches: [ main ]
-  push:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
## Type

CI

## Summary

Only run tests and integration tests on pull requests.
The main branch is protected, so we can't push to it directly. We assume testing is already done before merging into main.
