### PR TITLE
fix(mcp-server): use project-local server for custom support loading

### DIFF
--- a/packages/mcp-server/src/bootstrap.ts
+++ b/packages/mcp-server/src/bootstrap.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 
@@ -25,6 +25,19 @@ function resolveFromProject(moduleId: string, projectRoot: string): string | nul
   } catch {
     return null;
   }
+}
+
+function findPackageJsonPath(entryPath: string | null): string | null {
+  if (!entryPath) return null;
+
+  let dir = dirname(entryPath);
+  while (dir !== dirname(dir)) {
+    const packageJsonPath = resolve(dir, 'package.json');
+    if (existsSync(packageJsonPath)) return packageJsonPath;
+    dir = dirname(dir);
+  }
+
+  return null;
 }
 
 function toRealpath(path: string | null): string | null {
@@ -102,7 +115,8 @@ export function bootstrapProjectServer(): McpRuntimeMode {
   const currentReq = createRequire(import.meta.url);
 
   const currentPackageJsonPath = toRealpath(currentReq.resolve('../package.json'));
-  const projectPackageJsonPath = toRealpath(resolveFromProject('@letsrunit/mcp-server/package.json', projectRoot));
+  const projectEntryPath = resolveFromProject('@letsrunit/mcp-server', projectRoot);
+  const projectPackageJsonPath = toRealpath(findPackageJsonPath(projectEntryPath));
 
   const decision = decideHandoff(currentPackageJsonPath, projectPackageJsonPath, isBootstrapped);
 

--- a/packages/mcp-server/src/utility/support.ts
+++ b/packages/mcp-server/src/utility/support.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import { loadConfiguration } from '@cucumber/cucumber/api';
 import { registry } from '@letsrunit/bdd';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { glob } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -43,6 +43,13 @@ export type SupportDiagnostics = {
   supportEntries: SupportEntry[];
   loadedProjectRoots: string[];
   loadedSupportEntries: string[];
+  mcpServer: {
+    runtimeMode: string;
+    projectServerUsed: boolean;
+    serverMcpPath: string | null;
+    projectMcpPath: string | null;
+    sameModule: boolean;
+  };
   moduleResolution: {
     serverBddPath: string | null;
     projectBddPath: string | null;
@@ -155,6 +162,15 @@ function resolveFrom(moduleId: string, fromPath: string): string | null {
   }
 }
 
+function toRealpath(path: string | null): string | null {
+  if (!path) return null;
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
 export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDiagnostics> {
   const effectiveCwd = resolveEffectiveCwd(cwd);
   const projectRoot = resolve(effectiveCwd);
@@ -164,8 +180,11 @@ export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDi
   const ignorePatterns = await loadLetsrunitIgnorePatterns(projectRoot);
   const ignoredPaths = await expandPathPatterns(projectRoot, ignorePatterns);
   const supportEntries = await resolveSupportEntries(projectRoot, supportPatterns);
-  const serverBddPath = resolveFrom('@letsrunit/bdd', import.meta.url);
-  const projectBddPath = resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json'));
+  const serverBddPath = toRealpath(resolveFrom('@letsrunit/bdd', import.meta.url));
+  const projectBddPath = toRealpath(resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json')));
+  const serverMcpPath = toRealpath(resolveFrom('@letsrunit/mcp-server', import.meta.url));
+  const projectMcpPath = toRealpath(resolveFrom('@letsrunit/mcp-server', resolve(projectRoot, 'package.json')));
+  const runtimeMode = process.env.LETSRUNIT_MCP_RUNTIME_MODE ?? 'standalone';
   const registryDefinitions = registry.defs.map((def) => ({
     type: def.type,
     source: def.source,
@@ -185,6 +204,13 @@ export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDi
     supportEntries,
     loadedProjectRoots: [...loadedProjectRoots].sort(),
     loadedSupportEntries: [...loadedSupportEntries].sort(),
+    mcpServer: {
+      runtimeMode,
+      projectServerUsed: runtimeMode === 'project',
+      serverMcpPath,
+      projectMcpPath,
+      sameModule: !!serverMcpPath && !!projectMcpPath && serverMcpPath === projectMcpPath,
+    },
     moduleResolution: {
       serverBddPath,
       projectBddPath,

--- a/packages/mcp-server/tests/tools/diagnostics.test.ts
+++ b/packages/mcp-server/tests/tools/diagnostics.test.ts
@@ -17,6 +17,13 @@ vi.mock('../../src/utility/support', () => ({
     supportEntries: [{ kind: 'path', value: '/tmp/project/features/support/steps.ts' }],
     loadedProjectRoots: [],
     loadedSupportEntries: [],
+    mcpServer: {
+      runtimeMode: 'standalone',
+      projectServerUsed: false,
+      serverMcpPath: '/tmp/mcp/node_modules/@letsrunit/mcp-server/dist/index.js',
+      projectMcpPath: '/tmp/project/node_modules/@letsrunit/mcp-server/dist/index.js',
+      sameModule: false,
+    },
     moduleResolution: {
       serverBddPath: '/tmp/mcp/node_modules/@letsrunit/bdd/dist/index.js',
       projectBddPath: '/tmp/project/node_modules/@letsrunit/bdd/dist/index.js',
@@ -54,6 +61,7 @@ describe('registerDiagnostics', () => {
     expect(result.supportEntries).toEqual([
       { kind: 'path', value: '/tmp/project/features/support/steps.ts' },
     ]);
+    expect(result.mcpServer.runtimeMode).toBe('standalone');
     expect(result.moduleResolution.sameModule).toBe(false);
     expect(result.registry.total).toBe(1);
     expect(result.registry.byType.Given).toBe(1);

--- a/packages/mcp-server/tests/utility/support.test.ts
+++ b/packages/mcp-server/tests/utility/support.test.ts
@@ -61,6 +61,14 @@ describe('loadSupportFiles', () => {
     expect(diagnostics.effectiveCwd).toBe(cwd);
     expect(diagnostics.projectRoot).toBe(cwd);
     expect(diagnostics.cucumberConfigPath).toBe(join(cwd, 'cucumber.mjs'));
+    expect(diagnostics.mcpServer).toBeDefined();
+    expect(Object.keys(diagnostics.mcpServer).sort()).toEqual([
+      'projectMcpPath',
+      'projectServerUsed',
+      'runtimeMode',
+      'sameModule',
+      'serverMcpPath',
+    ]);
     expect(diagnostics.moduleResolution).toBeDefined();
     expect(Object.keys(diagnostics.moduleResolution).sort()).toEqual([
       'projectBddPath',


### PR DESCRIPTION
## Type

Bug fix

## Summary

Fix project-local MCP handoff so custom Cucumber support files/steps are actually loaded when a project has `@letsrunit/mcp-server` installed.

## Changes

- Resolve project-local MCP via `@letsrunit/mcp-server` entrypoint instead of blocked `@letsrunit/mcp-server/package.json` subpath.
- Derive package root from resolved entrypoint and use that for handoff decisions.
- Extend diagnostics output with explicit MCP mode fields:
  - `mcpServer.runtimeMode`
  - `mcpServer.projectServerUsed`
  - `mcpServer.serverMcpPath`
  - `mcpServer.projectMcpPath`
  - `mcpServer.sameModule`
- Added/updated tests for diagnostics payload and handoff behavior.

## Breaking changes

None.

## Validation

- `yarn test --project @letsrunit/mcp-server`
