### PR TITLE
fix(mcp-server): stabilize project handoff diagnostics and inject version

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,9 +1,10 @@
-import { createRequire } from 'module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { bootstrapProjectServer } from './bootstrap';
 
-const { version } = createRequire(import.meta.url)('../package.json') as { version: string };
+declare const __LETSRUNIT_VERSION__: string;
+
+const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
 bootstrapProjectServer();
 
 const { SessionManager } = await import('./sessions');

--- a/packages/mcp-server/src/utility/support.ts
+++ b/packages/mcp-server/src/utility/support.ts
@@ -7,6 +7,8 @@ import { isAbsolute, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { decideHandoff } from '../bootstrap';
 
+declare const __LETSRUNIT_VERSION__: string;
+
 type CucumberConfig = {
   require?: unknown;
   import?: unknown;
@@ -182,6 +184,10 @@ function pickLetsrunitEnv(): Record<string, string> {
   );
 }
 
+function resolveMcpServerVersion(): string {
+  return typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
+}
+
 export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDiagnostics> {
   const effectiveCwd = resolveEffectiveCwd(cwd);
   const projectRoot = resolve(effectiveCwd);
@@ -194,7 +200,6 @@ export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDi
   const serverBddPath = toRealpath(resolveFrom('@letsrunit/bdd', import.meta.url));
   const projectBddPath = toRealpath(resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json')));
   const projectMcpEntryPath = resolveFrom('@letsrunit/mcp-server', resolve(projectRoot, 'package.json'));
-  const currentReq = createRequire(import.meta.url);
   const currentEntrypointPath = toRealpath(fileURLToPath(import.meta.url));
   const projectEntrypointPath = toRealpath(projectMcpEntryPath);
   const handoffDecision = decideHandoff(
@@ -205,7 +210,7 @@ export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDi
   const serverMcpPath = toRealpath(resolveFrom('@letsrunit/mcp-server', import.meta.url));
   const projectMcpPath = toRealpath(projectMcpEntryPath);
   const executablePath = toRealpath(process.argv[1] ?? null);
-  const { version } = currentReq('../../package.json') as { version: string };
+  const version = resolveMcpServerVersion();
   const registryDefinitions = registry.defs.map((def) => ({
     type: def.type,
     source: def.source,

--- a/packages/mcp-server/tsup.config.ts
+++ b/packages/mcp-server/tsup.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'tsup';
+import { readFileSync } from 'node:fs';
+
+const { version } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+) as { version: string };
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -11,6 +16,9 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   outDir: 'dist',
+  define: {
+    __LETSRUNIT_VERSION__: JSON.stringify(version),
+  },
   banner: {
     js: "#!/usr/bin/env node\nimport * as __m from 'node:module'; const require = __m.createRequire(import.meta.url);",
   },


### PR DESCRIPTION
compare MCP server entrypoint realpaths for handoff decisions (remove package.json crawling)
- require sessionId in diagnostics and include session metadata
- add MCP diagnostics context: handoff decision, executable path, server/project mcp paths, and `LETSRUNIT_*` env vars
- remove redundant diagnostics runtimeMode field
- inject `__LETSRUNIT_VERSION__` at build time via tsup and use it in both server startup and diagnostics
