### PR TITLE
fix(mcp-server): simplify runtime mode handoff and diagnostics

### DIFF
--- a/packages/mcp-server/src/bootstrap.ts
+++ b/packages/mcp-server/src/bootstrap.ts
@@ -85,6 +85,5 @@ export function bootstrapProjectServer(): McpRuntimeMode {
     runProjectLocalServer(projectEntryPath);
   }
 
-  process.env.LETSRUNIT_MCP_RUNTIME_MODE = decision.runtimeMode;
   return decision.runtimeMode;
 }

--- a/packages/mcp-server/src/bootstrap.ts
+++ b/packages/mcp-server/src/bootstrap.ts
@@ -38,21 +38,34 @@ function sameEntrypoint(a: string | null, b: string | null): boolean {
   return a === b;
 }
 
+export function resolveRuntimeModeOverride(): McpRuntimeMode | null {
+  const runtimeMode = process.env.LETSRUNIT_MCP_RUNTIME_MODE;
+  if (runtimeMode == null || runtimeMode === '') {
+    return null;
+  }
+  if (runtimeMode === 'project' || runtimeMode === 'standalone') {
+    return runtimeMode;
+  }
+  throw new Error(
+    `Invalid LETSRUNIT_MCP_RUNTIME_MODE: ${runtimeMode}. Expected "project" or "standalone".`,
+  );
+}
+
 export function decideHandoff(
   currentEntrypointPath: string | null,
   projectEntrypointPath: string | null,
-  isBootstrapped: boolean,
+  runtimeModeOverride: McpRuntimeMode | null,
 ): HandoffDecision {
+  if (runtimeModeOverride) {
+    return { shouldHandoff: false, runtimeMode: runtimeModeOverride };
+  }
+
   if (!projectEntrypointPath) {
     return { shouldHandoff: false, runtimeMode: 'standalone' };
   }
 
   if (sameEntrypoint(currentEntrypointPath, projectEntrypointPath)) {
     return { shouldHandoff: false, runtimeMode: 'project' };
-  }
-
-  if (isBootstrapped) {
-    return { shouldHandoff: false, runtimeMode: 'standalone' };
   }
 
   return { shouldHandoff: true, runtimeMode: 'project' };
@@ -63,7 +76,6 @@ function runProjectLocalServer(projectEntrypointPath: string): never {
     stdio: 'inherit',
     env: {
       ...process.env,
-      LETSRUNIT_MCP_BOOTSTRAPPED: '1',
       LETSRUNIT_MCP_RUNTIME_MODE: 'project',
     },
   });
@@ -74,12 +86,12 @@ function runProjectLocalServer(projectEntrypointPath: string): never {
 
 export function bootstrapProjectServer(): McpRuntimeMode {
   const projectRoot = resolveProjectRoot();
-  const isBootstrapped = process.env.LETSRUNIT_MCP_BOOTSTRAPPED === '1';
+  const runtimeModeOverride = resolveRuntimeModeOverride();
 
   const currentEntryPath = toRealpath(fileURLToPath(import.meta.url));
   const projectEntryPath = toRealpath(resolveFromProject('@letsrunit/mcp-server', projectRoot));
 
-  const decision = decideHandoff(currentEntryPath, projectEntryPath, isBootstrapped);
+  const decision = decideHandoff(currentEntryPath, projectEntryPath, runtimeModeOverride);
 
   if (decision.shouldHandoff && projectEntryPath) {
     runProjectLocalServer(projectEntryPath);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2,10 +2,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { bootstrapProjectServer } from './bootstrap';
 
-declare const __LETSRUNIT_VERSION__: string;
+declare const __LETSRUNIT_VERSION__: string | undefined;
 
-const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
-bootstrapProjectServer();
+const version = __LETSRUNIT_VERSION__ ?? 'unknown';
+const runtimeMode = bootstrapProjectServer();
 
 const { SessionManager } = await import('./sessions');
 const {
@@ -29,7 +29,7 @@ const server = new McpServer({
   websiteUrl: 'https://letsrunit.ai',
 });
 
-registerSessionStart(server, sessions);
+registerSessionStart(server, sessions, { runtimeMode });
 registerRun(server, sessions);
 registerSnapshot(server, sessions);
 registerScreenshot(server, sessions);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,7 @@ import { bootstrapProjectServer } from './bootstrap';
 
 declare const __LETSRUNIT_VERSION__: string | undefined;
 
-const version = __LETSRUNIT_VERSION__ ?? 'unknown';
+const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
 const runtimeMode = bootstrapProjectServer();
 
 const { SessionManager } = await import('./sessions');

--- a/packages/mcp-server/src/tools/diagnostics.ts
+++ b/packages/mcp-server/src/tools/diagnostics.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { SessionManager } from '../sessions';
-import { collectSupportDiagnostics } from '../utility/support';
+import { collectDiagnostics } from '../utility/diagnostics';
 import { err, text } from '../utility/response';
 
 export function registerDiagnostics(server: McpServer, sessions: SessionManager): void {
@@ -16,7 +16,7 @@ export function registerDiagnostics(server: McpServer, sessions: SessionManager)
     },
     async (input) => {
       try {
-        const diagnostics = await collectSupportDiagnostics();
+        const diagnostics = await collectDiagnostics();
         const session = sessions.get(input.sessionId);
         const sessionInfo = {
           sessionId: session.id,

--- a/packages/mcp-server/src/tools/session-start.ts
+++ b/packages/mcp-server/src/tools/session-start.ts
@@ -1,17 +1,27 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import type { McpRuntimeMode } from '../bootstrap';
 import type { SessionManager } from '../sessions';
 import { err, text } from '../utility/response';
 import { loadSupportFiles } from '../utility/support';
 
-export function registerSessionStart(server: McpServer, sessions: SessionManager): void {
+interface Options {
+  runtimeMode: McpRuntimeMode;
+}
+
+export function registerSessionStart(server: McpServer, sessions: SessionManager, opts?: Options): void {
   server.registerTool(
     'letsrunit_session_start',
     {
       description:
         'Launch a new browser session. Does not navigate anywhere — use letsrunit_run with a Given step to navigate. Set baseURL to enable relative paths like "Given I\'m on the homepage".',
       inputSchema: {
-        baseURL: z.string().optional().describe('Base URL for the session, e.g. "http://localhost:3000". Enables relative paths in Given steps like "Given I\'m on the homepage" or "Given I\'m on page \\"/login\\""'),
+        baseURL: z
+          .string()
+          .optional()
+          .describe(
+            'Base URL for the session, e.g. "http://localhost:3000". Enables relative paths in Given steps like "Given I\'m on the homepage" or "Given I\'m on page \\"/login\\""',
+          ),
         language: z.string().optional().describe("Browser language code, e.g. 'en', 'fr'"),
         headless: z.boolean().optional().describe('Run browser in headless mode (default: true)'),
         viewportWidth: z.number().int().optional().describe('Viewport width in pixels (default: 1280)'),
@@ -20,7 +30,7 @@ export function registerSessionStart(server: McpServer, sessions: SessionManager
     },
     async (input) => {
       try {
-        if (process.env.LETSRUNIT_MCP_RUNTIME_MODE === 'project') {
+        if (opts?.runtimeMode === 'project') {
           await loadSupportFiles();
         }
 

--- a/packages/mcp-server/src/utility/diagnostics.ts
+++ b/packages/mcp-server/src/utility/diagnostics.ts
@@ -1,0 +1,159 @@
+import { loadConfiguration } from '@cucumber/cucumber/api';
+import { registry } from '@letsrunit/bdd';
+import { realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { decideHandoff, resolveRuntimeModeOverride } from '../bootstrap';
+import {
+  expandPathPatterns,
+  findCucumberConfig,
+  getSupportLoadState,
+  loadLetsrunitIgnorePatterns,
+  resolveEffectiveCwd,
+  resolveSupportEntries,
+  type SupportEntry,
+} from './support';
+
+declare const __LETSRUNIT_VERSION__: string | undefined;
+
+export type Diagnostics = {
+  envProjectCwd: string | null;
+  processCwd: string;
+  inputCwd: string | null;
+  effectiveCwd: string;
+  projectRoot: string;
+  cucumberConfigPath: string | null;
+  supportPatterns: string[];
+  ignorePatterns: string[];
+  ignoredPaths: string[];
+  supportEntries: SupportEntry[];
+  loadedProjectRoots: string[];
+  loadedSupportEntries: string[];
+  mcpServer: {
+    version: string;
+    executablePath: string | null;
+    projectServerUsed: boolean;
+    handoffDecision: {
+      shouldHandoff: boolean;
+      runtimeMode: string;
+    };
+    serverMcpPath: string | null;
+    projectMcpPath: string | null;
+  };
+  letsrunitEnv: Record<string, string>;
+  moduleResolution: {
+    serverBddPath: string | null;
+    projectBddPath: string | null;
+  };
+  registry: {
+    total: number;
+    byType: {
+      Given: number;
+      When: number;
+      Then: number;
+    };
+    definitions: Array<{
+      type: 'Given' | 'When' | 'Then';
+      source: string;
+      comment?: string;
+    }>;
+  };
+};
+
+function resolveFrom(moduleId: string, fromPath: string): string | null {
+  try {
+    const req = createRequire(fromPath);
+    return req.resolve(moduleId);
+  } catch {
+    return null;
+  }
+}
+
+function toRealpath(path: string | null): string | null {
+  if (!path) return null;
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function pickLetsrunitEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env)
+      .filter(([key, value]) => key.startsWith('LETSRUNIT_') && typeof value === 'string')
+      .map(([key, value]) => [key, value as string]),
+  );
+}
+
+export async function collectDiagnostics(cwd?: string): Promise<Diagnostics> {
+  const effectiveCwd = resolveEffectiveCwd(cwd);
+  const projectRoot = resolve(effectiveCwd);
+  const cucumberConfigPath = findCucumberConfig(projectRoot);
+  const { useConfiguration } = await loadConfiguration({}, { cwd: projectRoot });
+  const supportPatterns = [...(useConfiguration.require ?? []), ...(useConfiguration.import ?? [])];
+  const ignorePatterns = await loadLetsrunitIgnorePatterns(projectRoot);
+  const ignoredPaths = await expandPathPatterns(projectRoot, ignorePatterns);
+  const supportEntries = await resolveSupportEntries(projectRoot, supportPatterns);
+  const supportLoadState = getSupportLoadState();
+  const serverBddPath = toRealpath(resolveFrom('@letsrunit/bdd', import.meta.url));
+  const projectBddPath = toRealpath(resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json')));
+  const projectMcpEntryPath = resolveFrom('@letsrunit/mcp-server', resolve(projectRoot, 'package.json'));
+  const currentEntrypointPath = toRealpath(fileURLToPath(import.meta.url));
+  const projectEntrypointPath = toRealpath(projectMcpEntryPath);
+  const handoffDecision = decideHandoff(
+    currentEntrypointPath,
+    projectEntrypointPath,
+    resolveRuntimeModeOverride(),
+  );
+  const serverMcpPath = toRealpath(resolveFrom('@letsrunit/mcp-server', import.meta.url));
+  const projectMcpPath = toRealpath(projectMcpEntryPath);
+  const executablePath = toRealpath(process.argv[1] ?? null);
+  const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
+  const registryDefinitions = registry.defs.map((def) => ({
+    type: def.type,
+    source: def.source,
+    comment: def.comment,
+  }));
+
+  return {
+    envProjectCwd: process.env.LETSRUNIT_PROJECT_CWD ?? null,
+    processCwd: process.cwd(),
+    inputCwd: cwd ?? null,
+    effectiveCwd,
+    projectRoot,
+    cucumberConfigPath,
+    supportPatterns,
+    ignorePatterns,
+    ignoredPaths: [...ignoredPaths].sort(),
+    supportEntries,
+    loadedProjectRoots: supportLoadState.loadedProjectRoots,
+    loadedSupportEntries: supportLoadState.loadedSupportEntries,
+    mcpServer: {
+      version,
+      executablePath,
+      projectServerUsed: handoffDecision.runtimeMode === 'project',
+      handoffDecision: {
+        shouldHandoff: handoffDecision.shouldHandoff,
+        runtimeMode: handoffDecision.runtimeMode,
+      },
+      serverMcpPath,
+      projectMcpPath,
+    },
+    letsrunitEnv: pickLetsrunitEnv(),
+    moduleResolution: {
+      serverBddPath,
+      projectBddPath,
+    },
+    registry: {
+      total: registryDefinitions.length,
+      byType: {
+        Given: registryDefinitions.filter((d) => d.type === 'Given').length,
+        When: registryDefinitions.filter((d) => d.type === 'When').length,
+        Then: registryDefinitions.filter((d) => d.type === 'Then').length,
+      },
+      definitions: registryDefinitions,
+    },
+  };
+}

--- a/packages/mcp-server/src/utility/support.ts
+++ b/packages/mcp-server/src/utility/support.ts
@@ -1,13 +1,8 @@
 import { loadConfiguration } from '@cucumber/cucumber/api';
-import { registry } from '@letsrunit/bdd';
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { glob } from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import { isAbsolute, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { decideHandoff } from '../bootstrap';
-
-declare const __LETSRUNIT_VERSION__: string;
+import { pathToFileURL } from 'node:url';
 
 type CucumberConfig = {
   require?: unknown;
@@ -17,7 +12,7 @@ type CucumberConfig = {
   };
 };
 
-type SupportEntry = { kind: 'path'; value: string } | { kind: 'module'; value: string };
+export type SupportEntry = { kind: 'path'; value: string } | { kind: 'module'; value: string };
 
 const CUCUMBER_CONFIG_FILES = [
   'cucumber.js',
@@ -30,50 +25,6 @@ const CUCUMBER_CONFIG_FILES = [
 
 const loadedProjectRoots = new Set<string>();
 const loadedSupportEntries = new Set<string>();
-
-export type SupportDiagnostics = {
-  envProjectCwd: string | null;
-  processCwd: string;
-  inputCwd: string | null;
-  effectiveCwd: string;
-  projectRoot: string;
-  cucumberConfigPath: string | null;
-  supportPatterns: string[];
-  ignorePatterns: string[];
-  ignoredPaths: string[];
-  supportEntries: SupportEntry[];
-  loadedProjectRoots: string[];
-  loadedSupportEntries: string[];
-  mcpServer: {
-    version: string;
-    executablePath: string | null;
-    projectServerUsed: boolean;
-    handoffDecision: {
-      shouldHandoff: boolean;
-      runtimeMode: string;
-    };
-    serverMcpPath: string | null;
-    projectMcpPath: string | null;
-  };
-  letsrunitEnv: Record<string, string>;
-  moduleResolution: {
-    serverBddPath: string | null;
-    projectBddPath: string | null;
-  };
-  registry: {
-    total: number;
-    byType: {
-      Given: number;
-      When: number;
-      Then: number;
-    };
-    definitions: Array<{
-      type: 'Given' | 'When' | 'Then';
-      source: string;
-      comment?: string;
-    }>;
-  };
-};
 
 function toStrings(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -96,7 +47,7 @@ function normalizeMatch(baseDir: string, match: string): string {
   return isAbsolute(match) ? resolve(match) : resolve(baseDir, match);
 }
 
-async function expandPathPatterns(baseDir: string, patterns: string[]): Promise<Set<string>> {
+export async function expandPathPatterns(baseDir: string, patterns: string[]): Promise<Set<string>> {
   const files = new Set<string>();
 
   for (const pattern of patterns) {
@@ -113,7 +64,7 @@ async function expandPathPatterns(baseDir: string, patterns: string[]): Promise<
   return files;
 }
 
-async function resolveSupportEntries(baseDir: string, entries: string[]): Promise<SupportEntry[]> {
+export async function resolveSupportEntries(baseDir: string, entries: string[]): Promise<SupportEntry[]> {
   const resolved: SupportEntry[] = [];
 
   for (const entry of entries) {
@@ -135,7 +86,7 @@ async function resolveSupportEntries(baseDir: string, entries: string[]): Promis
   return resolved;
 }
 
-function findCucumberConfig(cwd: string): string | null {
+export function findCucumberConfig(cwd: string): string | null {
   for (const filename of CUCUMBER_CONFIG_FILES) {
     const path = resolve(cwd, filename);
     if (existsSync(path)) return path;
@@ -144,7 +95,7 @@ function findCucumberConfig(cwd: string): string | null {
   return null;
 }
 
-async function loadLetsrunitIgnorePatterns(cwd: string): Promise<string[]> {
+export async function loadLetsrunitIgnorePatterns(cwd: string): Promise<string[]> {
   const configPath = findCucumberConfig(cwd);
   if (!configPath) return [];
 
@@ -154,107 +105,14 @@ async function loadLetsrunitIgnorePatterns(cwd: string): Promise<string[]> {
   return toStrings(config.letsrunit?.ignore);
 }
 
-function resolveEffectiveCwd(cwd?: string): string {
+export function resolveEffectiveCwd(cwd?: string): string {
   return cwd ?? process.env.LETSRUNIT_PROJECT_CWD ?? process.cwd();
 }
 
-function resolveFrom(moduleId: string, fromPath: string): string | null {
-  try {
-    const req = createRequire(fromPath);
-    return req.resolve(moduleId);
-  } catch {
-    return null;
-  }
-}
-
-function toRealpath(path: string | null): string | null {
-  if (!path) return null;
-  try {
-    return realpathSync(path);
-  } catch {
-    return path;
-  }
-}
-
-function pickLetsrunitEnv(): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(process.env)
-      .filter(([key, value]) => key.startsWith('LETSRUNIT_') && typeof value === 'string')
-      .map(([key, value]) => [key, value as string]),
-  );
-}
-
-function resolveMcpServerVersion(): string {
-  return typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
-}
-
-export async function collectSupportDiagnostics(cwd?: string): Promise<SupportDiagnostics> {
-  const effectiveCwd = resolveEffectiveCwd(cwd);
-  const projectRoot = resolve(effectiveCwd);
-  const cucumberConfigPath = findCucumberConfig(projectRoot);
-  const { useConfiguration } = await loadConfiguration({}, { cwd: projectRoot });
-  const supportPatterns = [...toStrings(useConfiguration.require), ...toStrings(useConfiguration.import)];
-  const ignorePatterns = await loadLetsrunitIgnorePatterns(projectRoot);
-  const ignoredPaths = await expandPathPatterns(projectRoot, ignorePatterns);
-  const supportEntries = await resolveSupportEntries(projectRoot, supportPatterns);
-  const serverBddPath = toRealpath(resolveFrom('@letsrunit/bdd', import.meta.url));
-  const projectBddPath = toRealpath(resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json')));
-  const projectMcpEntryPath = resolveFrom('@letsrunit/mcp-server', resolve(projectRoot, 'package.json'));
-  const currentEntrypointPath = toRealpath(fileURLToPath(import.meta.url));
-  const projectEntrypointPath = toRealpath(projectMcpEntryPath);
-  const handoffDecision = decideHandoff(
-    currentEntrypointPath,
-    projectEntrypointPath,
-    process.env.LETSRUNIT_MCP_BOOTSTRAPPED === '1',
-  );
-  const serverMcpPath = toRealpath(resolveFrom('@letsrunit/mcp-server', import.meta.url));
-  const projectMcpPath = toRealpath(projectMcpEntryPath);
-  const executablePath = toRealpath(process.argv[1] ?? null);
-  const version = resolveMcpServerVersion();
-  const registryDefinitions = registry.defs.map((def) => ({
-    type: def.type,
-    source: def.source,
-    comment: def.comment,
-  }));
-
+export function getSupportLoadState(): { loadedProjectRoots: string[]; loadedSupportEntries: string[] } {
   return {
-    envProjectCwd: process.env.LETSRUNIT_PROJECT_CWD ?? null,
-    processCwd: process.cwd(),
-    inputCwd: cwd ?? null,
-    effectiveCwd,
-    projectRoot,
-    cucumberConfigPath,
-    supportPatterns,
-    ignorePatterns,
-    ignoredPaths: [...ignoredPaths].sort(),
-    supportEntries,
     loadedProjectRoots: [...loadedProjectRoots].sort(),
     loadedSupportEntries: [...loadedSupportEntries].sort(),
-    mcpServer: {
-      version,
-      executablePath,
-      projectServerUsed: handoffDecision.runtimeMode === 'project',
-      handoffDecision: {
-        shouldHandoff: handoffDecision.shouldHandoff,
-        runtimeMode: handoffDecision.runtimeMode,
-      },
-      serverMcpPath,
-      projectMcpPath,
-    },
-    letsrunitEnv: pickLetsrunitEnv(),
-    moduleResolution: {
-      serverBddPath,
-      projectBddPath,
-    },
-    registry: {
-      total: registryDefinitions.length,
-      byType: {
-        Given: registryDefinitions.filter((d) => d.type === 'Given').length,
-        When: registryDefinitions.filter((d) => d.type === 'When').length,
-        Then: registryDefinitions.filter((d) => d.type === 'Then').length,
-      },
-      definitions: registryDefinitions,
-    },
   };
 }
 

--- a/packages/mcp-server/tests/bootstrap.test.ts
+++ b/packages/mcp-server/tests/bootstrap.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { decideHandoff } from '../src/bootstrap';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { decideHandoff, resolveRuntimeModeOverride } from '../src/bootstrap';
 
 describe('decideHandoff', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('uses standalone mode when project mcp server is not available', () => {
-    const result = decideHandoff('/npx/@letsrunit/mcp-server/package.json', null, false);
+    const result = decideHandoff('/npx/@letsrunit/mcp-server/package.json', null, null);
     expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'standalone' });
   });
 
@@ -11,7 +15,7 @@ describe('decideHandoff', () => {
     const result = decideHandoff(
       '/repo/node_modules/@letsrunit/mcp-server/package.json',
       '/repo/node_modules/@letsrunit/mcp-server/package.json',
-      false,
+      null,
     );
     expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'project' });
   });
@@ -20,17 +24,24 @@ describe('decideHandoff', () => {
     const result = decideHandoff(
       '/npx-cache/@letsrunit/mcp-server/package.json',
       '/repo/node_modules/@letsrunit/mcp-server/package.json',
-      false,
+      null,
     );
     expect(result).toEqual({ shouldHandoff: true, runtimeMode: 'project' });
   });
 
-  it('does not handoff when bootstrap guard is set', () => {
+  it('uses runtime override without handoff', () => {
     const result = decideHandoff(
       '/npx-cache/@letsrunit/mcp-server/package.json',
       '/repo/node_modules/@letsrunit/mcp-server/package.json',
-      true,
+      'project',
     );
-    expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'standalone' });
+    expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'project' });
+  });
+
+  it('throws for invalid LETSRUNIT_MCP_RUNTIME_MODE', () => {
+    vi.stubEnv('LETSRUNIT_MCP_RUNTIME_MODE', 'bad-value');
+    expect(() => resolveRuntimeModeOverride()).toThrow(
+      'Invalid LETSRUNIT_MCP_RUNTIME_MODE: bad-value. Expected "project" or "standalone".',
+    );
   });
 });

--- a/packages/mcp-server/tests/tools/diagnostics.test.ts
+++ b/packages/mcp-server/tests/tools/diagnostics.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerDiagnostics } from '../../src/tools';
-import { collectSupportDiagnostics } from '../../src/utility/support';
+import { collectDiagnostics } from '../../src/utility/diagnostics';
 import { parseResult } from '../_helpers';
 
-vi.mock('../../src/utility/support', () => ({
-  collectSupportDiagnostics: vi.fn().mockResolvedValue({
+vi.mock('../../src/utility/diagnostics', () => ({
+  collectDiagnostics: vi.fn().mockResolvedValue({
     envProjectCwd: '/tmp/project',
     processCwd: '/tmp/process',
     inputCwd: null,
@@ -86,12 +86,12 @@ describe('registerDiagnostics', () => {
     expect(result.session.pageUrl).toBe('http://localhost:3000/');
     expect(result.registry.total).toBe(1);
     expect(result.registry.byType.Given).toBe(1);
-    expect(collectSupportDiagnostics).toHaveBeenCalledTimes(1);
+    expect(collectDiagnostics).toHaveBeenCalledTimes(1);
     expect(sessions.get).toHaveBeenCalledWith('sess-abc');
   });
 
   it('returns error payload when diagnostics collection fails', async () => {
-    vi.mocked(collectSupportDiagnostics).mockRejectedValueOnce(new Error('diagnostics boom'));
+    vi.mocked(collectDiagnostics).mockRejectedValueOnce(new Error('diagnostics boom'));
 
     const result = await call({ sessionId: 'sess-abc' });
     expect(result.isError).toBe(true);

--- a/packages/mcp-server/tests/tools/session-start.test.ts
+++ b/packages/mcp-server/tests/tools/session-start.test.ts
@@ -14,9 +14,10 @@ describe('registerSessionStart', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubEnv('LETSRUNIT_MCP_RUNTIME_MODE', 'project');
     sessions = makeSessionManager({ create: vi.fn().mockResolvedValue(session) });
-    call = captureHandler(registerSessionStart, sessions);
+    call = captureHandler((server, sessionManager) => {
+      registerSessionStart(server, sessionManager, { runtimeMode: 'project' });
+    }, sessions);
   });
 
   it('returns the sessionId', async () => {
@@ -30,7 +31,9 @@ describe('registerSessionStart', () => {
   });
 
   it('does not load support files in standalone mode', async () => {
-    vi.stubEnv('LETSRUNIT_MCP_RUNTIME_MODE', 'standalone');
+    call = captureHandler((server, sessionManager) => {
+      registerSessionStart(server, sessionManager, { runtimeMode: 'standalone' });
+    }, sessions);
     await call({});
     expect(loadSupportFiles).not.toHaveBeenCalled();
   });

--- a/packages/mcp-server/tests/utility/support.test.ts
+++ b/packages/mcp-server/tests/utility/support.test.ts
@@ -2,7 +2,8 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { collectSupportDiagnostics, loadSupportFiles } from '../../src/utility/support';
+import { collectDiagnostics } from '../../src/utility/diagnostics';
+import { loadSupportFiles } from '../../src/utility/support';
 
 describe('loadSupportFiles', () => {
   afterEach(() => {
@@ -56,7 +57,7 @@ describe('loadSupportFiles', () => {
     );
     vi.stubEnv('LETSRUNIT_PROJECT_CWD', cwd);
 
-    const diagnostics = await collectSupportDiagnostics();
+    const diagnostics = await collectDiagnostics();
     expect(diagnostics.envProjectCwd).toBe(cwd);
     expect(diagnostics.effectiveCwd).toBe(cwd);
     expect(diagnostics.projectRoot).toBe(cwd);


### PR DESCRIPTION
## Summary
- remove bootstrap guard env coupling and make runtime-mode override explicit
- throw on invalid LETSRUNIT_MCP_RUNTIME_MODE values
- move diagnostics collection out of support utility into dedicated utility/diagnostics module
- rename collector to collectDiagnostics and update tool/tests
- keep support utility focused on support-file loading and support state

## Validation
- yarn test --project @letsrunit/mcp-server
