### PR TITLE
fix(mcp-server): add explicit step reload tool

### DIFF
--- a/packages/bdd/src/index.ts
+++ b/packages/bdd/src/index.ts
@@ -1,5 +1,20 @@
 export * from './parameters';
-export * from './steps';
 export * from './types';
 export { toFile } from './utils/file';
-export { Given, When, Then, registry, createRegistry } from './registry';
+export { Given, When, Then, registry, createRegistry, resetRegistry } from './registry';
+import './steps';
+import { registry } from './registry';
+
+const builtInDefinitions = registry.definitions.map((definition) => ({
+  type: definition.type,
+  expression: definition.expression,
+  fn: definition.fn,
+  comment: definition.comment,
+}));
+
+export function resetRegistryToBuiltInSteps(): void {
+  registry.reset();
+  for (const definition of builtInDefinitions) {
+    registry.defineStep(definition.type, definition.expression, definition.fn, definition.comment);
+  }
+}

--- a/packages/bdd/src/registry.ts
+++ b/packages/bdd/src/registry.ts
@@ -16,15 +16,19 @@ interface Entry {
   expr: CucumberExpression | RegularExpression;
 }
 
-export function createRegistry() {
-  const _paramRegistry = new ParameterTypeRegistry();
-  const _entries: Entry[] = [];
-
+function createParameterRegistry(): ParameterTypeRegistry {
+  const registry = new ParameterTypeRegistry();
   for (const t of typeDefinitions) {
-    _paramRegistry.defineParameterType(
+    registry.defineParameterType(
       new ParameterType(t.name, t.regexp, null, t.transformer as any, t.useForSnippets),
     );
   }
+  return registry;
+}
+
+export function createRegistry() {
+  let _paramRegistry = createParameterRegistry();
+  const _entries: Entry[] = [];
 
   return {
     /** IStepRegistry-compatible defs (source = String(expression), no raw expr). */
@@ -60,6 +64,11 @@ export function createRegistry() {
       );
     },
 
+    reset(): void {
+      _entries.length = 0;
+      _paramRegistry = createParameterRegistry();
+    },
+
     match(text: string) {
       for (const entry of _entries) {
         const args = entry.expr.match(text);
@@ -83,6 +92,10 @@ type GlobalRegistryStore = typeof globalThis & {
 
 const registryStore = globalThis as GlobalRegistryStore;
 export const registry = registryStore[REGISTRY_KEY] ?? (registryStore[REGISTRY_KEY] = createRegistry());
+
+export function resetRegistry(): void {
+  registry.reset();
+}
 
 export function Given(expression: string | RegExp, fn: StepHandler, comment?: string): StepDefinition {
   const def: StepDefinition = { type: 'Given', expression, fn, comment };

--- a/packages/bdd/tests/reload.test.ts
+++ b/packages/bdd/tests/reload.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Given, registry, resetRegistry, resetRegistryToBuiltInSteps } from '../src/index';
+
+describe('registry reload helpers', () => {
+  afterEach(() => {
+    resetRegistryToBuiltInSteps();
+  });
+
+  it('resetRegistry clears all step definitions', () => {
+    Given('a temporary custom step for reset test', () => {});
+    expect(registry.defs.length).toBeGreaterThan(0);
+
+    resetRegistry();
+
+    expect(registry.defs).toHaveLength(0);
+  });
+
+  it('resetRegistryToBuiltInSteps restores built-in definitions', () => {
+    const builtInCount = registry.defs.length;
+    Given('a temporary custom step for restore test', () => {});
+    expect(registry.defs.length).toBe(builtInCount + 1);
+
+    resetRegistryToBuiltInSteps();
+
+    expect(registry.defs.length).toBe(builtInCount);
+  });
+});

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -61,6 +61,8 @@ At runtime, letsrunit checks the current project:
 
 So custom steps from `features/support/**` are available when `@letsrunit/mcp-server` is installed in that project.
 
+When you edit existing support files during a long-running agent session, call `letsrunit_reload` to rebuild and reload step definitions without restarting the agent.
+
 ## Tools
 
 | Tool | Description |
@@ -71,6 +73,7 @@ So custom steps from `features/support/**` are available when `@letsrunit/mcp-se
 | `letsrunit_snapshot` | Get the current page HTML, scrubbed for LLM consumption. Scope to a DOM subtree with `selector`. |
 | `letsrunit_screenshot` | Take a screenshot. Optionally crop to a selector or highlight elements before capturing. |
 | `letsrunit_debug` | Evaluate JavaScript on the current page via `page.evaluate()`. Use for debugging, not test logic. |
+| `letsrunit_reload` | Rebuild and reload built-in + project support step definitions after step-file changes. Available in project runtime mode. |
 | `letsrunit_diagnostics` | Return runtime diagnostics (`cwd`, `LETSRUNIT_PROJECT_CWD`, detected cucumber config, resolved support entries). Available only when `LETSRUNIT_MCP_DIAGNOSTICS=enabled`. |
 | `letsrunit_session_close` | Close a browser session and release its resources. |
 | `letsrunit_list_sessions` | List all active browser sessions. |

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -14,6 +14,7 @@ const {
   registerDiff,
   registerListSteps,
   registerListSessions,
+  registerReload,
   registerRun,
   registerScreenshot,
   registerSessionClose,
@@ -37,6 +38,7 @@ registerDebug(server, sessions);
 registerSessionClose(server, sessions);
 registerListSteps(server, sessions);
 registerListSessions(server, sessions);
+registerReload(server, { runtimeMode });
 registerDiff(server, sessions);
 if (process.env.LETSRUNIT_MCP_DIAGNOSTICS === 'enabled') {
   registerDiagnostics(server, sessions);

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -4,6 +4,7 @@ export { registerDiff } from './diff';
 export { registerListSteps } from './list-steps';
 export { registerListSessions } from './list-sessions';
 export { registerRun } from './run';
+export { registerReload } from './reload';
 export { registerScreenshot } from './screenshot';
 export { registerSessionClose } from './session-close';
 export { registerSessionStart } from './session-start';

--- a/packages/mcp-server/src/tools/reload.ts
+++ b/packages/mcp-server/src/tools/reload.ts
@@ -1,4 +1,3 @@
-import { resetRegistryToBuiltInSteps } from '@letsrunit/bdd';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpRuntimeMode } from '../bootstrap';
@@ -8,6 +7,17 @@ import { reloadSupportFiles } from '../utility/support';
 type Options = {
   runtimeMode: McpRuntimeMode;
 };
+
+async function resetBuiltInStepRegistry(): Promise<void> {
+  const bdd = (await import('@letsrunit/bdd')) as Record<string, unknown>;
+  const reset = bdd.resetRegistryToBuiltInSteps;
+  if (typeof reset !== 'function') {
+    throw new Error(
+      'Installed @letsrunit/bdd does not expose resetRegistryToBuiltInSteps. Update @letsrunit/bdd to a compatible version.',
+    );
+  }
+  reset();
+}
 
 export function registerReload(server: McpServer, options: Options): void {
   server.registerTool(
@@ -28,7 +38,7 @@ export function registerReload(server: McpServer, options: Options): void {
       }
 
       try {
-        resetRegistryToBuiltInSteps();
+        await resetBuiltInStepRegistry();
         const result = await reloadSupportFiles(input.cwd);
         return text(
           JSON.stringify({

--- a/packages/mcp-server/src/tools/reload.ts
+++ b/packages/mcp-server/src/tools/reload.ts
@@ -1,0 +1,46 @@
+import { resetRegistryToBuiltInSteps } from '@letsrunit/bdd';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { McpRuntimeMode } from '../bootstrap';
+import { err, text } from '../utility/response';
+import { reloadSupportFiles } from '../utility/support';
+
+type Options = {
+  runtimeMode: McpRuntimeMode;
+};
+
+export function registerReload(server: McpServer, options: Options): void {
+  server.registerTool(
+    'letsrunit_reload',
+    {
+      description:
+        'Reload built-in and project support step definitions without restarting the MCP server.',
+      inputSchema: {
+        cwd: z
+          .string()
+          .optional()
+          .describe('Project directory to resolve cucumber support files from. Defaults to current project cwd.'),
+      },
+    },
+    async (input) => {
+      if (options.runtimeMode !== 'project') {
+        return err('Reload failed: letsrunit_reload is only available in project runtime mode.');
+      }
+
+      try {
+        resetRegistryToBuiltInSteps();
+        const result = await reloadSupportFiles(input.cwd);
+        return text(
+          JSON.stringify({
+            reloaded: true,
+            projectRoot: result.projectRoot,
+            supportEntriesLoaded: result.supportEntriesLoaded,
+            ignoredEntries: result.ignoredEntries,
+          }),
+        );
+      } catch (e) {
+        return err(`Reload failed: ${(e as Error).message}`);
+      }
+    },
+  );
+}

--- a/packages/mcp-server/src/utility/support.ts
+++ b/packages/mcp-server/src/utility/support.ts
@@ -26,6 +26,16 @@ const CUCUMBER_CONFIG_FILES = [
 const loadedProjectRoots = new Set<string>();
 const loadedSupportEntries = new Set<string>();
 
+export type SupportLoadResult = {
+  projectRoot: string;
+  supportEntriesLoaded: number;
+  ignoredEntries: number;
+};
+
+type LoadSupportOptions = {
+  forceReload?: boolean;
+};
+
 function toStrings(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((entry): entry is string => typeof entry === 'string');
@@ -116,37 +126,62 @@ export function getSupportLoadState(): { loadedProjectRoots: string[]; loadedSup
   };
 }
 
-export async function loadSupportFiles(cwd?: string): Promise<void> {
+export function clearSupportLoadState(): void {
+  loadedProjectRoots.clear();
+  loadedSupportEntries.clear();
+}
+
+function buildReloadedFileUrl(path: string): string {
+  const url = pathToFileURL(path);
+  url.searchParams.set('letsrunitReload', Date.now().toString(36));
+  return url.href;
+}
+
+export async function loadSupportFiles(cwd?: string, options?: LoadSupportOptions): Promise<SupportLoadResult> {
   const projectRoot = resolve(resolveEffectiveCwd(cwd));
-  if (loadedProjectRoots.has(projectRoot)) return;
+  const forceReload = options?.forceReload === true;
+
+  if (!forceReload && loadedProjectRoots.has(projectRoot)) {
+    return { projectRoot, supportEntriesLoaded: 0, ignoredEntries: 0 };
+  }
 
   const { useConfiguration } = await loadConfiguration({}, { cwd: projectRoot });
   const supportPatterns = [...toStrings(useConfiguration.require), ...toStrings(useConfiguration.import)];
   if (supportPatterns.length === 0) {
     loadedProjectRoots.add(projectRoot);
-    return;
+    return { projectRoot, supportEntriesLoaded: 0, ignoredEntries: 0 };
   }
 
   const ignorePatterns = await loadLetsrunitIgnorePatterns(projectRoot);
   const ignoredPaths = await expandPathPatterns(projectRoot, ignorePatterns);
   const supportEntries = await resolveSupportEntries(projectRoot, supportPatterns);
+  let supportEntriesLoaded = 0;
+  let ignoredEntries = 0;
 
   for (const entry of supportEntries) {
     if (entry.kind === 'path' && ignoredPaths.has(entry.value)) {
+      ignoredEntries += 1;
       continue;
     }
 
     const key = `${entry.kind}:${entry.value}`;
-    if (loadedSupportEntries.has(key)) continue;
+    if (!forceReload && loadedSupportEntries.has(key)) continue;
 
     if (entry.kind === 'path') {
-      await import(pathToFileURL(entry.value).href);
+      await import(forceReload ? buildReloadedFileUrl(entry.value) : pathToFileURL(entry.value).href);
     } else {
       await import(entry.value);
     }
 
+    supportEntriesLoaded += 1;
     loadedSupportEntries.add(key);
   }
 
   loadedProjectRoots.add(projectRoot);
+  return { projectRoot, supportEntriesLoaded, ignoredEntries };
+}
+
+export async function reloadSupportFiles(cwd?: string): Promise<SupportLoadResult> {
+  clearSupportLoadState();
+  return loadSupportFiles(cwd, { forceReload: true });
 }

--- a/packages/mcp-server/tests/tools/reload.test.ts
+++ b/packages/mcp-server/tests/tools/reload.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetRegistryToBuiltInSteps } from '@letsrunit/bdd';
+import { registerReload } from '../../src/tools/reload';
+import { reloadSupportFiles } from '../../src/utility/support';
+import { captureHandler, parseResult } from '../_helpers';
+
+vi.mock('@letsrunit/bdd', () => ({
+  resetRegistryToBuiltInSteps: vi.fn(),
+}));
+
+vi.mock('../../src/utility/support', () => ({
+  reloadSupportFiles: vi.fn(),
+}));
+
+describe('registerReload', () => {
+  let call: (input: any) => Promise<any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(reloadSupportFiles).mockResolvedValue({
+      projectRoot: '/tmp/project',
+      supportEntriesLoaded: 2,
+      ignoredEntries: 1,
+    });
+    call = captureHandler((server) => registerReload(server as any, { runtimeMode: 'project' }), {} as any);
+  });
+
+  it('resets registry and reloads support files in project mode', async () => {
+    const result = parseResult(await call({}));
+
+    expect(resetRegistryToBuiltInSteps).toHaveBeenCalledTimes(1);
+    expect(reloadSupportFiles).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      reloaded: true,
+      projectRoot: '/tmp/project',
+      supportEntriesLoaded: 2,
+      ignoredEntries: 1,
+    });
+  });
+
+  it('passes cwd to reloadSupportFiles when provided', async () => {
+    await call({ cwd: '/repo/app' });
+    expect(reloadSupportFiles).toHaveBeenCalledWith('/repo/app');
+  });
+
+  it('returns an error outside project mode', async () => {
+    const standaloneCall = captureHandler(
+      (server) => registerReload(server as any, { runtimeMode: 'standalone' }),
+      {} as any,
+    );
+    const result = await standaloneCall({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('only available in project runtime mode');
+    expect(resetRegistryToBuiltInSteps).not.toHaveBeenCalled();
+    expect(reloadSupportFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when reload fails', async () => {
+    vi.mocked(reloadSupportFiles).mockRejectedValueOnce(new Error('reload boom'));
+
+    const result = await call({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('reload boom');
+  });
+});

--- a/packages/mcp-server/tests/tools/reload.test.ts
+++ b/packages/mcp-server/tests/tools/reload.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resetRegistryToBuiltInSteps } from '@letsrunit/bdd';
+import * as bdd from '@letsrunit/bdd';
 import { registerReload } from '../../src/tools/reload';
 import { reloadSupportFiles } from '../../src/utility/support';
 import { captureHandler, parseResult } from '../_helpers';
@@ -28,7 +28,7 @@ describe('registerReload', () => {
   it('resets registry and reloads support files in project mode', async () => {
     const result = parseResult(await call({}));
 
-    expect(resetRegistryToBuiltInSteps).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(bdd.resetRegistryToBuiltInSteps)).toHaveBeenCalledTimes(1);
     expect(reloadSupportFiles).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       reloaded: true,
@@ -52,7 +52,7 @@ describe('registerReload', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('only available in project runtime mode');
-    expect(resetRegistryToBuiltInSteps).not.toHaveBeenCalled();
+    expect(vi.mocked(bdd.resetRegistryToBuiltInSteps)).not.toHaveBeenCalled();
     expect(reloadSupportFiles).not.toHaveBeenCalled();
   });
 

--- a/packages/mcp-server/tests/utility/support.test.ts
+++ b/packages/mcp-server/tests/utility/support.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { collectDiagnostics } from '../../src/utility/diagnostics';
-import { loadSupportFiles } from '../../src/utility/support';
+import { loadSupportFiles, reloadSupportFiles } from '../../src/utility/support';
 
 describe('loadSupportFiles', () => {
   afterEach(() => {
@@ -79,5 +79,31 @@ describe('loadSupportFiles', () => {
     ]);
     expect(diagnostics.registry).toBeDefined();
     expect(Object.keys(diagnostics.registry.byType).sort()).toEqual(['Given', 'Then', 'When']);
+  });
+
+  it('reloads changed support files without restarting process', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'letsrunit-mcp-reload-'));
+    const supportDir = join(cwd, 'features', 'support');
+    await mkdir(supportDir, { recursive: true });
+
+    await writeFile(
+      join(cwd, 'cucumber.mjs'),
+      `export default {
+  import: ['features/support/*.mjs'],
+  require: [],
+};`,
+      'utf8',
+    );
+
+    const stepPath = join(supportDir, 'steps.mjs');
+    await writeFile(stepPath, 'globalThis.__mcpReloadValue = (globalThis.__mcpReloadValue ?? 0) + 1;', 'utf8');
+
+    (globalThis as any).__mcpReloadValue = 0;
+    await loadSupportFiles(cwd);
+    expect((globalThis as any).__mcpReloadValue).toBe(1);
+
+    await writeFile(stepPath, 'globalThis.__mcpReloadValue = (globalThis.__mcpReloadValue ?? 0) + 10;', 'utf8');
+    await reloadSupportFiles(cwd);
+    expect((globalThis as any).__mcpReloadValue).toBe(11);
   });
 });


### PR DESCRIPTION
## Summary
- add new MCP tool `letsrunit_reload` to rebuild and reload step definitions without restarting the agent
- add `resetRegistry()` and `resetRegistryToBuiltInSteps()` in `@letsrunit/bdd`
- update support loader with forced reload mode and cache-busted file imports for changed support files
- wire the reload tool into mcp server startup and tool exports
- document `letsrunit_reload` in the mcp-server README

## Validation
- yarn test --project @letsrunit/bdd --project @letsrunit/mcp-server
