### PR TITLE
feat(gherkin): support within iframe locator traversal

### DIFF
--- a/docs/writing-tests/locators.md
+++ b/docs/writing-tests/locators.md
@@ -29,6 +29,15 @@ letsrunit resolves locators in priority order: accessible names first, then visi
 When I click button "Submit" within `#checkout-form`
 ```
 
+To target elements inside an iframe, scope with `within iframe "..."`:
+
+```gherkin
+When I click button "Submit" within iframe "ownable widget"
+```
+
+The iframe name matches case-insensitively against iframe `title`, `name`, `aria-label`, or `id`.
+If multiple iframes match, the step fails and you should use a more specific name.
+
 **Filter** by descendants with `with` or `without`:
 
 ```gherkin

--- a/packages/gherkin/src/locator/compile.ts
+++ b/packages/gherkin/src/locator/compile.ts
@@ -54,6 +54,10 @@ function escapeForAttributeSelector(value: string, exact = false): string {
   return `"${value.trim().replace(/\\/g, '\\\\').replace(/["]/g, '\\"')}"${exact ? 's' : 'i'}`;
 }
 
+function escapeForCssAttributeValue(value: string): string {
+  return value.trim().replace(/\\/g, '\\\\').replace(/["]/g, '\\"');
+}
+
 // ---------- Builders for internal engines ----------
 function getByAttributeTextSelector(attrName: string, text: string, props = ''): string {
   return `[${attrName}=${escapeForAttributeSelector(text)}]` + (props ? ` ${props}` : '');
@@ -81,6 +85,23 @@ function getByDateSelector(text: string): string {
 
 function getByRoleSelector(role: string, name: string = '', props = ''): string {
   return `role=${role}` + (name ? ` [name=${escapeForAttributeSelector(name)}]` : '') + (props ? ` ${props}` : '');
+}
+
+function isIframeRoleSelector(sel: Selector): sel is RoleSelector {
+  return sel.mode === 'role' && sel.role.toLowerCase() === 'iframe' && !!sel.name;
+}
+
+function getByIframeSelector(name: string): string {
+  const value = escapeForCssAttributeValue(name);
+  return `css=iframe:is([title="${value}" i],[name="${value}" i],[aria-label="${value}" i],[id="${value}" i])`;
+}
+
+function compileAncestorSelector(sel: Selector): string {
+  if (isIframeRoleSelector(sel)) {
+    return `${getByIframeSelector(sel.name)} >> internal:control=enter-frame`;
+  }
+
+  return compileBaseSelector(sel);
 }
 
 // ---------- Core compile helpers ----------
@@ -148,7 +169,7 @@ export function compileLocator(input: string): string {
   const ast = parse(input) as Expr;
 
   // 1) compile ancestor containers (outer → inner)
-  const chain: string[] = ast.ancestors.map(compileBaseSelector);
+  const chain: string[] = ast.ancestors.map(compileAncestorSelector);
 
   // 2) compile base
   const base = compileBaseSelector(ast.base.selector);

--- a/packages/gherkin/tests/locator/compile.test.ts
+++ b/packages/gherkin/tests/locator/compile.test.ts
@@ -112,6 +112,18 @@ describe('compileLocator', () => {
     );
   });
 
+  it('button "Foo" within iframe "ownable widget" enters iframe then finds the target', () => {
+    expect(compileLocator('button "Foo" within iframe "ownable widget"')).to.eq(
+      'css=iframe:is([title="ownable widget" i],[name="ownable widget" i],[aria-label="ownable widget" i],[id="ownable widget" i]) >> internal:control=enter-frame >> role=button [name="Foo"i]',
+    );
+  });
+
+  it('supports chains combining iframe and non-iframe ancestors', () => {
+    expect(compileLocator('button "Save" within iframe "widget" within `#shell`')).to.eq(
+      'css=iframe:is([title="widget" i],[name="widget" i],[aria-label="widget" i],[id="widget" i]) >> internal:control=enter-frame >> #shell >> role=button [name="Save"i]',
+    );
+  });
+
   it('supports multiple within clauses in parser order', () => {
     expect(compileLocator('button "Save" within `section` within `#root`')).to.eq(
       'section >> #root >> role=button [name="Save"i]',

--- a/packages/gherkin/tests/locator/regexp.test.ts
+++ b/packages/gherkin/tests/locator/regexp.test.ts
@@ -29,6 +29,8 @@ describe('locatorRegexp', () => {
     'field "Email" within `form#signup`',
     'section within `form#main`',
     'section with text "Hello" within `css=.foo >> nth(2)`',
+    'button "Foo" within iframe "ownable widget"',
+    'button "Save" within iframe "widget" within `#shell`',
     'pager',
     'the pager',
     'pageable',

--- a/packages/gherkin/tests/parameters.test.ts
+++ b/packages/gherkin/tests/parameters.test.ts
@@ -169,6 +169,13 @@ describe('locatorParameter', () => {
     expect(arg.getValue(null)).to.eq('role=button [name="Submit"i]');
   });
 
+  it('compiles iframe-scoped locators using enter-frame', () => {
+    const [arg] = expr.match('button "Submit" within iframe "ownable widget"')!;
+    expect(arg.getValue(null)).to.eq(
+      'css=iframe:is([title="ownable widget" i],[name="ownable widget" i],[aria-label="ownable widget" i],[id="ownable widget" i]) >> internal:control=enter-frame >> role=button [name="Submit"i]',
+    );
+  });
+
   it('returns the raw locator when compile fails', () => {
     const param = locatorParameter();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Type

Feature

## Summary

Add first-class iframe scoping to locator compilation so steps can target elements inside named iframes using within iframe "...".

## Changes

- compile within iframe "name" to iframe matching (title, name, aria-label, id) plus Playwright frame traversal
- add gherkin locator compile, regexp, and parameter tests for iframe-scoped locators
- document iframe locator scoping and strict ambiguity behavior in locator docs

## Breaking changes

None.