### PR TITLE
feat: add password value literals and optional CLI target fallback

### DIFF
--- a/docs/writing-tests/gherkin-basics.md
+++ b/docs/writing-tests/gherkin-basics.md
@@ -85,7 +85,9 @@ letsrunit extends Cucumber with three parameter types used across the step libra
 | Type | Accepts | Example |
 |------|---------|---------|
 | `{locator}` | Any locator expression | `button "Sign in"`, `field "Email"`, `` `#submit` `` |
-| `{value}` | String, number, date expression, or array | `"hello"`, `42`, `date of tomorrow`, `["A", "B"]` |
+| `{value}` | String, number, date expression, generated password, or array | `"hello"`, `42`, `date of tomorrow`, `password of "user-uuid"`, `["A", "B"]` |
+
+`password of "..."` requires the `LETSRUNIT_PASSWORD_SEED` environment variable.
 | `{keys}` | Quoted key or key combination | `"Enter"`, `"Control+A"`, `"Shift+Tab"` |
 
 See [Locators](locators.md) for the full locator syntax and [Step Reference](step-reference.md) for every available step.

--- a/docs/writing-tests/step-reference.md
+++ b/docs/writing-tests/step-reference.md
@@ -78,7 +78,10 @@ When I set field "Price range" to range of 10 to 100
 | Boolean | `true` / `false` |
 | Date (absolute) | `date "2025-01-22"` |
 | Date (relative) | `date of tomorrow`, `date of 3 days ago`, `date of 8 weeks from now` |
+| Generated password | `password of "user-uuid"` |
 | Array | `["Option A", "Option B"]` |
+
+To use `password of "..."`, set `LETSRUNIT_PASSWORD_SEED` in your environment.
 
 ## Keyboard
 

--- a/packages/bdd/tests/steps/form.test.ts
+++ b/packages/bdd/tests/steps/form.test.ts
@@ -42,6 +42,26 @@ describe('steps/form (definitions)', () => {
     expect(setFieldValue).toHaveBeenLastCalledWith(testLocator, expect.any(Date), { timeout: 500 });
   });
 
+  it('sets a locator with generated password value', async () => {
+    const previousSeed = process.env.LETSRUNIT_PASSWORD_SEED;
+    try {
+      process.env.LETSRUNIT_PASSWORD_SEED = 'test-seed';
+      const { setFieldValue } = await import('@letsrunit/playwright');
+      const page = {} as any;
+
+      await runStep(setStep, 'I set `#password` to password of "user-1"', { page } as any);
+      expect(setFieldValue).toHaveBeenCalledWith(testLocator, expect.stringMatching(/^Lr![a-f0-9]{18}a1$/), {
+        timeout: 500,
+      });
+    } finally {
+      if (previousSeed === undefined) {
+        delete process.env.LETSRUNIT_PASSWORD_SEED;
+      } else {
+        process.env.LETSRUNIT_PASSWORD_SEED = previousSeed;
+      }
+    }
+  });
+
   it('clears a locator', async () => {
     const { setFieldValue } = await import('@letsrunit/playwright');
     const page = {} as any;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,13 +9,13 @@ The `letsrunit` CLI allows you to explore websites, generate Gherkin features us
 ### `explore`
 Navigates a target URL and allows interactive discovery of features.
 ```bash
-yarn cli explore <url>
+yarn cli explore --target <url>
 ```
 
 ### `generate`
 Generates a `.feature` file from natural language instructions.
 ```bash
-echo "Login with email and password" | yarn cli generate <url> -o ./features
+echo "Login with email and password" | yarn cli generate --target <url> -o ./features
 ```
 
 ### `explain`
@@ -26,6 +26,7 @@ yarn cli explain --db .letsrunit/letsrunit.db --artifacts .letsrunit/artifacts
 ```
 
 ## Options
+- `-t, --target <target>`: Target URL or project. If omitted, letsrunit reads `worldParameters` from `cucumber.js` (for example `baseURL`) and falls back to `http://localhost:3000`.
 - `-v, --verbose`: Enable verbose logging.
 - `-s, --silent`: Only output errors.
 - `-o, --save <path>`: Path to save generated artifacts/features.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runExplain } from './run-explain';
 import { runExplore } from './run-explore';
+import { resolveTarget } from './target';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version: string };
@@ -59,12 +60,13 @@ program
 program
   .command('explore')
   .description('Generate feature scenarios by exploring a URL')
-  .argument('<target>', 'Target URL or project')
+  .option('-t, --target <target>', 'Target URL or project')
   .option('-v, --verbose', 'Enable verbose logging', false)
   .option('-s, --silent', 'Only output errors', false)
   .option('-o, --save <path>', 'Path to save .feature file', '')
-  .action(async (target: string, opts: { verbose: boolean; silent: boolean; save: string }) => {
+  .action(async (opts: { target?: string; verbose: boolean; silent: boolean; save: string }) => {
     const journal = createJournal({ ...opts, artifactPath: opts.save });
+    const target = await resolveTarget(opts.target);
 
     const { status } = await explore(target, { headless: false, journal }, async (info, actions) => {
       journal.sink.endSection();
@@ -77,11 +79,11 @@ program
 program
   .command('generate')
   .description('Generate a feature scenario from a test description')
-  .argument('<target>', 'Target URL or project')
+  .option('-t, --target <target>', 'Target URL or project')
   .option('-v, --verbose', 'Enable verbose logging', false)
   .option('-s, --silent', 'Only output errors', false)
   .option('-o, --save <path>', 'Path to save .feature file', '')
-  .action(async (target: string, opts: { verbose: boolean; silent: boolean; save: string }) => {
+  .action(async (opts: { target?: string; verbose: boolean; silent: boolean; save: string }) => {
     const instructions = (await readStdin()).trim();
 
     if (!instructions) {
@@ -93,6 +95,7 @@ program
 
     await journal.info('Refining test instructions');
     const suggestion = await refineSuggestion(instructions);
+    const target = await resolveTarget(opts.target);
 
     const { feature, status } = await generate(target, suggestion, { headless: false, journal });
 
@@ -106,11 +109,11 @@ program
 program
   .command('register')
   .description('Register a test user in your app')
-  .argument('<target>', 'Target URL or project')
+  .option('-t, --target <target>', 'Target URL or project')
   .option('-v, --verbose', 'Enable verbose logging', false)
   .option('-s, --silent', 'Only output errors', false)
   .option('-o, --save <path>', 'Path to save .feature file', '')
-  .action(async (target: string, opts: { verbose: boolean; silent: boolean; save: string }) => {
+  .action(async (opts: { target?: string; verbose: boolean; silent: boolean; save: string }) => {
     const journal = createJournal({ ...opts, artifactPath: opts.save });
 
     const suggestion = {
@@ -126,6 +129,7 @@ program
     };
 
     const email = getMailbox(randomUUID());
+    const target = await resolveTarget(opts.target);
 
     const { feature, status } = await generate(target, suggestion, { headless: false, journal, accounts: { email } });
 

--- a/packages/cli/src/target.ts
+++ b/packages/cli/src/target.ts
@@ -1,0 +1,58 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_TARGET = 'http://localhost:3000';
+const CUCUMBER_CONFIG_FILES = [
+  'cucumber.js',
+  'cucumber.mjs',
+  'cucumber.cjs',
+  'cucumber.ts',
+  'cucumber.mts',
+  'cucumber.cts',
+];
+
+type CucumberConfig = {
+  worldParameters?: unknown;
+};
+
+function readTargetFromWorldParameters(worldParameters: unknown): string | undefined {
+  if (!worldParameters || typeof worldParameters !== 'object') return undefined;
+
+  const values = worldParameters as Record<string, unknown>;
+  const candidate = values.url ?? values.baseURL ?? values.baseUrl ?? values.target;
+  if (typeof candidate !== 'string') return undefined;
+
+  const target = candidate.trim();
+  return target.length > 0 ? target : undefined;
+}
+
+function findCucumberConfig(cwd: string): string | undefined {
+  for (const filename of CUCUMBER_CONFIG_FILES) {
+    const configPath = resolve(cwd, filename);
+    if (existsSync(configPath)) return configPath;
+  }
+
+  return undefined;
+}
+
+async function readTargetFromCucumberWorldParameters(cwd: string): Promise<string | undefined> {
+  const configPath = findCucumberConfig(cwd);
+  if (!configPath) return undefined;
+
+  try {
+    const module = await import(pathToFileURL(configPath).href);
+    const config = (module.default ?? module) as CucumberConfig;
+    return readTargetFromWorldParameters(config.worldParameters);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveTarget(target?: string): Promise<string> {
+  const explicitTarget = target?.trim();
+  if (explicitTarget) return explicitTarget;
+
+  return (await readTargetFromCucumberWorldParameters(process.cwd())) ?? DEFAULT_TARGET;
+}
+

--- a/packages/cli/tests/target.test.ts
+++ b/packages/cli/tests/target.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveTarget } from '../src/target';
+
+const initialCwd = process.cwd();
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  process.chdir(initialCwd);
+
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function createTempProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'letsrunit-cli-target-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('resolveTarget', () => {
+  it('uses explicit --target when provided', async () => {
+    const target = await resolveTarget('https://explicit.example');
+    expect(target).toBe('https://explicit.example');
+  });
+
+  it('reads baseURL from cucumber.js worldParameters', async () => {
+    const cwd = await createTempProject();
+    await writeFile(
+      join(cwd, 'cucumber.js'),
+      "export default { worldParameters: { baseURL: 'https://from-cucumber.example' } };",
+      'utf-8',
+    );
+    process.chdir(cwd);
+
+    const target = await resolveTarget();
+    expect(target).toBe('https://from-cucumber.example');
+  });
+
+  it('falls back to localhost when cucumber.js is missing', async () => {
+    const cwd = await createTempProject();
+    process.chdir(cwd);
+
+    const target = await resolveTarget();
+    expect(target).toBe('http://localhost:3000');
+  });
+
+  it('falls back to localhost when worldParameters has no URL target', async () => {
+    const cwd = await createTempProject();
+    await writeFile(join(cwd, 'cucumber.js'), 'export default { worldParameters: { headless: true } };', 'utf-8');
+    process.chdir(cwd);
+
+    const target = await resolveTarget();
+    expect(target).toBe('http://localhost:3000');
+  });
+});
+

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      exclude: [
+        '**/tests/**',
+        'src/index.ts',
+      ],
+    },
+  },
+});
+

--- a/packages/executor/src/ai/generate-feature.ts
+++ b/packages/executor/src/ai/generate-feature.ts
@@ -43,7 +43,7 @@ Only use the following \`When\` steps:
 
 * \`{locator}\` - A readable description of a page element
 * \`{keys}\` - Keyboard input like "Enter" or "CTRL + S"
-* \`{value}\` - A string, number, or date, for example "Hello", 10, \`date of tomorrow\`, or \`date "2026-02-22"\`
+* \`{value}\` - A string, number, date, or generated password, for example "Hello", 10, \`date of tomorrow\`, \`date "2026-02-22"\`, or \`password of "user-uuid"\`
 
 **Locator rules**:
 ${locatorRules}

--- a/packages/gherkin/src/value.ts
+++ b/packages/gherkin/src/value.ts
@@ -1,10 +1,26 @@
 import { parseDateString, type Scalar } from '@letsrunit/utils';
+import { createHmac } from 'node:crypto';
 
 export const scalarRegexp =
-  /"((?:[^"\\]+|\\.)*)"|(-?\d+(?:\.\d+)?)|date (?:of )?((?:today|tomorrow|yesterday|\d+ \w+ (?:ago|from now))(?: (?:at )?\d\d?:\d\d?(?::\d\d?)?)?|"\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?(?:.\d{3})?Z?)?")/;
+  /password of "((?:[^"\\]+|\\.)*)"|"((?:[^"\\]+|\\.)*)"|(-?\d+(?:\.\d+)?)|date (?:of )?((?:today|tomorrow|yesterday|\d+ \w+ (?:ago|from now))(?: (?:at )?\d\d?:\d\d?(?::\d\d?)?)?|"\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?(?:.\d{3})?Z?)?")/;
 export const arrayRegexp = new RegExp(String.raw`\[(.*?)\]`);
 
-function transformScalar(str?: string, num?: string, date?: string): Scalar {
+function requirePasswordSeed(): string {
+  const seed = process.env.LETSRUNIT_PASSWORD_SEED?.trim();
+  if (!seed) {
+    throw new Error('LETSRUNIT_PASSWORD_SEED is required to use password values (password of "...").');
+  }
+
+  return seed;
+}
+
+function buildPassword(input: string): string {
+  const digest = createHmac('sha256', requirePasswordSeed()).update(input).digest('hex');
+  return `Lr!${digest.slice(0, 18)}a1`;
+}
+
+function transformScalar(password?: string, str?: string, num?: string, date?: string): Scalar {
+  if (password != null) return buildPassword(password);
   if (str != null) return str;
   if (num != null) return Number(num);
   if (date) return parseDateString(date);
@@ -13,12 +29,13 @@ function transformScalar(str?: string, num?: string, date?: string): Scalar {
 }
 
 export const valueTransformer = (
+  password?: string,
   str?: string,
   num?: string,
   date?: string,
   arr?: string,
 ): Scalar | Scalar[] => {
   return arr
-    ? Array.from(arr.matchAll(new RegExp(scalarRegexp, 'g')), (m) => transformScalar(m[1], m[2], m[3]))
-    : transformScalar(str, num, date);
+    ? Array.from(arr.matchAll(new RegExp(scalarRegexp, 'g')), (m) => transformScalar(m[1], m[2], m[3], m[4]))
+    : transformScalar(password, str, num, date);
 };

--- a/packages/gherkin/tests/parameters.test.ts
+++ b/packages/gherkin/tests/parameters.test.ts
@@ -1,5 +1,5 @@
 import { CucumberExpression, ParameterType, ParameterTypeRegistry } from '@cucumber/cucumber-expressions';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   booleanParameter,
   enumParameter,
@@ -79,12 +79,26 @@ describe('valueParameter', () => {
   let param: ParameterTypeDefinition<unknown>;
   let reg: ParameterTypeRegistry;
   let expr: CucumberExpression;
+  let originalPasswordSeed: string | undefined;
 
   beforeAll(() => {
     param = valueParameter();
     reg = new ParameterTypeRegistry();
     defineParameterType(reg, param);
     expr = new CucumberExpression('value is {value}', reg);
+  });
+
+  beforeEach(() => {
+    originalPasswordSeed = process.env.LETSRUNIT_PASSWORD_SEED;
+  });
+
+  afterEach(() => {
+    if (originalPasswordSeed === undefined) {
+      delete process.env.LETSRUNIT_PASSWORD_SEED;
+      return;
+    }
+
+    process.env.LETSRUNIT_PASSWORD_SEED = originalPasswordSeed;
   });
 
   it('parses a quoted string value', () => {
@@ -127,6 +141,29 @@ describe('valueParameter', () => {
     expect(formatDateTimeLocal(value as Date)).to.eq('1981-08-22T15:04');
   });
 
+  it('parses a password value deterministically', () => {
+    process.env.LETSRUNIT_PASSWORD_SEED = 'test-seed';
+
+    const [a] = expr.match('value is password of "user-1"')!;
+    const [b] = expr.match('value is password of "user-1"')!;
+    const [c] = expr.match('value is password of "user-2"')!;
+
+    const valueA = a.getValue(null);
+    const valueB = b.getValue(null);
+    const valueC = c.getValue(null);
+
+    expect(valueA).to.eq(valueB);
+    expect(valueA).not.to.eq(valueC);
+    expect(valueA).to.match(/^Lr![a-f0-9]{18}a1$/);
+  });
+
+  it('throws when password value is used without LETSRUNIT_PASSWORD_SEED', () => {
+    delete process.env.LETSRUNIT_PASSWORD_SEED;
+
+    const [v] = expr.match('value is password of "user-1"')!;
+    expect(() => v.getValue(null)).toThrow('LETSRUNIT_PASSWORD_SEED is required');
+  });
+
   it('parses an array of values', () => {
     const res = expr.match('value is ["foo", 42]');
     expect(res).not.to.be.null;
@@ -148,6 +185,19 @@ describe('valueParameter', () => {
     expect(val[0]).to.be.instanceOf(Date);
     expect(val[1]).to.be.instanceOf(Date);
     expect(formatDateTimeLocal(val[1] as Date)).to.eq('1981-08-22T15:04');
+  });
+
+  it('parses an array containing password values', () => {
+    process.env.LETSRUNIT_PASSWORD_SEED = 'test-seed';
+
+    const res = expr.match('value is [password of "user-1", "fallback"]');
+    expect(res).not.to.be.null;
+
+    const [v] = res!;
+    const val = v.getValue(null) as any[];
+    expect(val).to.have.length(2);
+    expect(val[0]).to.match(/^Lr![a-f0-9]{18}a1$/);
+    expect(val[1]).to.eq('fallback');
   });
 });
 


### PR DESCRIPTION
## Type

Feature

## Summary

Improve CLI ergonomics by making target resolution optional with sensible defaults, and add a deterministic `password of "..."` `{value}` type with explicit seed requirements for reproducible test credentials.

## Changes

- Make `explore`, `generate`, and `register` use `--target <target>` instead of required positional target.
- Resolve target from `cucumber.*` `worldParameters` (`url`/`baseURL`/`baseUrl`/`target`) and fall back to `http://localhost:3000`.
- Add `{value}` support for `password of "..."` with deterministic password generation.
- Enforce `LETSRUNIT_PASSWORD_SEED` for password generation and throw a clear error when missing.
- Add/extend tests in `@letsrunit/cli`, `@letsrunit/gherkin`, and `@letsrunit/bdd`.
- Update docs and skill docs, and bump `agent` submodule pointer.

## Breaking changes

No breaking API changes. `password of "..."` requires `LETSRUNIT_PASSWORD_SEED` when used.