### PR TITLE
fix(cucumber): stream compact agent formatter output

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,5 +1,12 @@
+import { isAgentEnvironment } from '@letsrunit/cucumber/config';
+
 export default {
   import: ['features/support/*.js'],
+  format: [
+    isAgentEnvironment(process.env)
+      ? '@letsrunit/cucumber/agent'
+      : '@letsrunit/cucumber/progress',
+  ],
   worldParameters: {
     baseURL: 'https://todomvc.com/examples/react/dist/',
   },

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -120,6 +120,9 @@ export default {
 Machine-oriented formatter that emits one JSON object per line (NDJSON):
 
 - `run_start`, `scenario_start`, `step_result`, `scenario_end`, `run_end` events
+- compact payloads: no `schema_version`, `timestamp`, `event_id`, or `sequence`
+- `run_id` is emitted only in `run_start`
+- `will_be_retried` is emitted only when `true`
 - Failure events include exact raw error text and structured fields (`summary`, `locator`, `url`, etc.)
 - When store plugin data is available, failure events include baseline metadata and inline unified HTML diff
 

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -37,10 +37,10 @@ export default {
 
 ### Debug Run Policy Helper
 
-Use `@letsrunit/cucumber/config` to derive `failFast` and `worldParameters` from CLI args:
+Use `@letsrunit/cucumber/config` to derive `failFast` and `worldParameters` from CLI args and pick the formatter based on the current agent environment:
 
 ```js
-import { resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
+import { isAgentEnvironment, resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
 
 const { failFast, worldParameters } = resolveDebugWorldParameters({
   argv: process.argv,
@@ -49,11 +49,27 @@ const { failFast, worldParameters } = resolveDebugWorldParameters({
   },
 });
 
+const format = [
+  isAgentEnvironment(process.env)
+    ? '@letsrunit/cucumber/agent'
+    : '@letsrunit/cucumber/progress',
+];
+
 export default {
-  format: ['@letsrunit/cucumber/progress'],
+  format,
   failFast,
   worldParameters,
 };
+```
+
+Pass extra env var keys for other agents:
+
+```js
+const format = [
+  isAgentEnvironment(process.env, ['FOO_AGENT'])
+    ? '@letsrunit/cucumber/agent'
+    : '@letsrunit/cucumber/progress',
+];
 ```
 
 Running headed + fail-fast:

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -123,7 +123,7 @@ Machine-oriented formatter that emits one JSON object per line (NDJSON):
 - compact payloads: no `schema_version`, `timestamp`, `event_id`, or `sequence`
 - `run_id` is emitted only in `run_start`
 - `will_be_retried` is emitted only when `true`
-- Failure events include exact raw error text and structured fields (`summary`, `locator`, `url`, etc.)
+- Failure events include `failure.error` (ANSI-stripped full message) and flattened fields (`kind`, `summary`, `locator`, `locator_full`, `url`, etc.)
 - When store plugin data is available, failure events include baseline metadata and inline unified HTML diff
 
 ```js

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -1,4 +1,5 @@
 import { formatterHelpers, type IFormatterOptions, Formatter } from '@cucumber/cucumber';
+import { type Envelope, TestStepResultStatus } from '@cucumber/messages';
 import { normalizeSteps } from '@letsrunit/gherkin';
 import { findArtifacts, findLastTest, openStore, computeScenarioId, computeStepId } from '@letsrunit/store';
 import { unifiedHtmlDiff } from '@letsrunit/playwright';
@@ -58,14 +59,19 @@ type BaselineContext = {
   artifactDir: string;
 };
 
-const SCHEMA_VERSION = '1';
+type ScenarioContext = {
+  scenarioId?: string;
+  attempt: number;
+  stepIndexById: Map<string, number>;
+};
 
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
-function normalizeStatus(status: string): string {
-  return status.toLowerCase();
+function normalizeStatus(status: string | number | undefined): string {
+  if (typeof status === 'string') return status.toLowerCase();
+  if (typeof status === 'number') {
+    const name = TestStepResultStatus[status];
+    if (typeof name === 'string') return name.toLowerCase();
+  }
+  return 'unknown';
 }
 
 function toDurationMs(duration?: { seconds?: number; nanos?: number }): number | undefined {
@@ -226,10 +232,20 @@ export default class AgentFormatter extends Formatter {
   static readonly documentation = 'Machine-focused NDJSON formatter for agent consumption.';
 
   private readonly runId = uuidv4();
-  private sequence = 0;
+  private runStarted = false;
+  private processing: Promise<void> = Promise.resolve();
+  private passed = 0;
+  private failed = 0;
+  private skipped = 0;
+  private readonly scenarios = new Map<string, ScenarioContext>();
 
   constructor(options: IFormatterOptions) {
     super(options);
+    options.eventBroadcaster.on('envelope', (envelope: Envelope) => {
+      this.processing = this.processing.then(async () => {
+        await this.handleEnvelope(envelope);
+      });
+    });
   }
 
   private createBaseFailurePayload(step: ParsedStep): Pick<FailurePayload, 'error_raw' | 'error_structured'> {
@@ -346,23 +362,15 @@ export default class AgentFormatter extends Formatter {
     }
   }
 
-  private nextEventMeta(): { event_id: string; sequence: number } {
-    this.sequence += 1;
-    return {
-      event_id: `${this.runId}:${this.sequence}`,
-      sequence: this.sequence,
-    };
-  }
-
   private emit(payload: Record<string, unknown>): void {
-    emitLine(this.log, { ...this.nextEventMeta(), ...payload });
+    emitLine(this.log, payload);
   }
 
   private emitRunStart(): void {
+    if (this.runStarted) return;
+    this.runStarted = true;
     this.emit({
-      schema_version: SCHEMA_VERSION,
       event_type: 'run_start',
-      timestamp: nowIso(),
       run_id: this.runId,
     });
   }
@@ -371,16 +379,11 @@ export default class AgentFormatter extends Formatter {
     scenario: ParsedScenario,
     scenarioId: string | undefined,
     attempt: number,
-    willBeRetried: boolean,
   ): void {
     this.emit({
-      schema_version: SCHEMA_VERSION,
       event_type: 'scenario_start',
-      timestamp: nowIso(),
-      run_id: this.runId,
       scenario_id: scenarioId,
       attempt,
-      will_be_retried: willBeRetried,
       name: scenario.name,
       uri: scenario.sourceLocation?.uri,
       line: scenario.sourceLocation?.line,
@@ -393,24 +396,19 @@ export default class AgentFormatter extends Formatter {
     attempt: number,
     willBeRetried: boolean,
   ): void {
-    this.emit({
-      schema_version: SCHEMA_VERSION,
+    const payload: Record<string, unknown> = {
       event_type: 'scenario_end',
-      timestamp: nowIso(),
-      run_id: this.runId,
       scenario_id: scenarioId,
       attempt,
-      will_be_retried: willBeRetried,
       status,
-    });
+    };
+    if (willBeRetried) payload.will_be_retried = true;
+    this.emit(payload);
   }
 
   private emitRunEnd(passed: number, failed: number, skipped: number): void {
     this.emit({
-      schema_version: SCHEMA_VERSION,
       event_type: 'run_end',
-      timestamp: nowIso(),
-      run_id: this.runId,
       status: failed > 0 ? 'failed' : 'passed',
       scenarios: { passed, failed, skipped },
     });
@@ -421,17 +419,12 @@ export default class AgentFormatter extends Formatter {
     step: ParsedStep,
     idx: number,
     attempt: number,
-    willBeRetried: boolean,
   ): Promise<void> {
     const status = normalizeStatus(step.result.status);
     const baseEvent: Record<string, unknown> = {
-      schema_version: SCHEMA_VERSION,
       event_type: 'step_result',
-      timestamp: nowIso(),
-      run_id: this.runId,
       scenario_id: scenarioId,
       attempt,
-      will_be_retried: willBeRetried,
       step_index: idx,
       keyword: step.keyword,
       text: step.text,
@@ -448,42 +441,116 @@ export default class AgentFormatter extends Formatter {
     this.emit(baseEvent);
   }
 
-  async finished(): Promise<void> {
-    this.emitRunStart();
-
-    const attempts = this.eventDataCollector.getTestCaseAttempts();
-    let passed = 0;
-    let failed = 0;
-    let skipped = 0;
-
-    for (const attempt of attempts) {
+  private parseAttempt(testCaseStartedId: string): { scenario: ParsedScenario; steps: ParsedStep[]; attempt: number } | null {
+    try {
+      const attempt = this.eventDataCollector.getTestCaseAttempt(testCaseStartedId);
       const parsed = formatterHelpers.parseTestCaseAttempt({
         snippetBuilder: this.snippetBuilder,
         supportCodeLibrary: this.supportCodeLibrary,
         testCaseAttempt: attempt,
       });
+      return {
+        scenario: parsed.testCase as ParsedScenario,
+        steps: parsed.testSteps as ParsedStep[],
+        attempt: attempt.attempt + 1,
+      };
+    } catch {
+      return null;
+    }
+  }
 
-      const scenario = parsed.testCase as ParsedScenario;
-      const steps = parsed.testSteps as ParsedStep[];
-      const scenarioId = toScenarioId(steps) ?? undefined;
-      const scenarioStatus = normalizeStatus(attempt.worstTestStepResult.status);
-      const scenarioAttempt = attempt.attempt + 1;
+  private async handleTestCaseStarted(envelope: Envelope): Promise<void> {
+    const started = envelope.testCaseStarted;
+    if (!started) return;
 
-      this.emitScenarioStart(scenario, scenarioId, scenarioAttempt, attempt.willBeRetried);
+    const parsed = this.parseAttempt(started.id);
+    if (!parsed) return;
 
-      for (let idx = 0; idx < steps.length; idx += 1) {
-        await this.emitStepResult(scenarioId, steps[idx], idx, scenarioAttempt, attempt.willBeRetried);
-      }
+    const attemptData = this.eventDataCollector.getTestCaseAttempt(started.id);
+    const stepIndexById = new Map<string, number>();
+    attemptData.testCase.testSteps.forEach((step, idx) => {
+      stepIndexById.set(step.id, idx);
+    });
 
-      if (scenarioStatus === 'passed') passed += 1;
-      else if (scenarioStatus === 'skipped') skipped += 1;
-      else failed += 1;
+    const scenarioId = toScenarioId(parsed.steps) ?? undefined;
+    this.scenarios.set(started.id, {
+      scenarioId,
+      attempt: parsed.attempt,
+      stepIndexById,
+    });
 
-      this.emitScenarioEnd(scenarioId, scenarioStatus, scenarioAttempt, attempt.willBeRetried);
+    this.emitScenarioStart(parsed.scenario, scenarioId, parsed.attempt);
+  }
+
+  private async handleTestStepFinished(envelope: Envelope): Promise<void> {
+    const finished = envelope.testStepFinished;
+    if (!finished) return;
+
+    const context = this.scenarios.get(finished.testCaseStartedId);
+    if (!context) return;
+
+    const parsed = this.parseAttempt(finished.testCaseStartedId);
+    if (!parsed) return;
+
+    const stepIndex = context.stepIndexById.get(finished.testStepId);
+    if (stepIndex === undefined) return;
+
+    const step = parsed.steps[stepIndex];
+    if (!step) return;
+
+    await this.emitStepResult(context.scenarioId, step, stepIndex, context.attempt);
+  }
+
+  private handleTestCaseFinished(envelope: Envelope): void {
+    const finished = envelope.testCaseFinished;
+    if (!finished) return;
+
+    const context = this.scenarios.get(finished.testCaseStartedId);
+    const attemptData = this.eventDataCollector.getTestCaseAttempt(finished.testCaseStartedId);
+    const status = normalizeStatus(attemptData.worstTestStepResult.status);
+    const attempt = context?.attempt ?? attemptData.attempt + 1;
+    const scenarioId = context?.scenarioId;
+
+    if (status === 'passed') this.passed += 1;
+    else if (status === 'skipped') this.skipped += 1;
+    else this.failed += 1;
+
+    this.emitScenarioEnd(scenarioId, status, attempt, finished.willBeRetried);
+    this.scenarios.delete(finished.testCaseStartedId);
+  }
+
+  private handleTestRunFinished(): void {
+    this.emitRunEnd(this.passed, this.failed, this.skipped);
+  }
+
+  private async handleEnvelope(envelope: Envelope): Promise<void> {
+    if (envelope.testRunStarted) {
+      this.emitRunStart();
+      return;
     }
 
-    this.emitRunEnd(passed, failed, skipped);
+    if (envelope.testCaseStarted) {
+      await this.handleTestCaseStarted(envelope);
+      return;
+    }
 
+    if (envelope.testStepFinished) {
+      await this.handleTestStepFinished(envelope);
+      return;
+    }
+
+    if (envelope.testCaseFinished) {
+      this.handleTestCaseFinished(envelope);
+      return;
+    }
+
+    if (envelope.testRunFinished) {
+      this.handleTestRunFinished();
+    }
+  }
+
+  async finished(): Promise<void> {
+    await this.processing;
     await super.finished();
   }
 }

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -76,7 +76,8 @@ type ScenarioContext = {
 function normalizeStatus(status: string | number | undefined): string {
   if (typeof status === 'string') return status.toLowerCase();
   if (typeof status === 'number') {
-    const name = TestStepResultStatus[status];
+    const names = TestStepResultStatus as Record<number, string>;
+    const name = names[status];
     if (typeof name === 'string') return name.toLowerCase();
   }
   return 'unknown';

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -29,6 +29,7 @@ type FailureStructured = {
   kind: 'assertion' | 'timeout' | 'navigation' | 'unknown';
   summary?: string;
   locator?: string;
+  locator_full?: string;
   url?: string;
   expected?: string;
   actual?: string;
@@ -44,8 +45,15 @@ type DiffReason =
   | 'diff_compute_failed';
 
 type FailurePayload = {
-  error_raw: string;
-  error_structured: FailureStructured;
+  error: string;
+  kind: FailureStructured['kind'];
+  summary?: string;
+  locator?: string;
+  locator_full?: string;
+  url?: string;
+  expected?: string;
+  actual?: string;
+  timeout_ms?: number;
   baseline?: { test_id: string; commit: string | null; screenshots: string[] };
   diff?: string;
   diff_available: boolean;
@@ -119,18 +127,32 @@ function isStackLine(line: string): boolean {
   return /^\s*at\s+/.test(line);
 }
 
-function trimLocator(locator: string): string {
-  const raw = locator.trim();
-  const match = raw.match(/^locator\((['"`])(.*)\1\)(?:\.[A-Za-z_]\w*\([^)]*\))*$/);
-  if (!match) return raw;
-  return match[2];
+function stripAnsi(input: string): string {
+  // Regex from chalk/strip-ansi to remove ANSI escape sequences
+  const pattern =
+    /[\u001B\u009B][[\]()#;?]*(?:((?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
+  return input.replace(pattern, '');
 }
 
-function extractLocator(lines: string[]): string | undefined {
+function simplifyLocator(locator: string): string {
+  const raw = locator.trim();
+  const firstLocatorMatch = raw.match(/locator\((['"`])([\s\S]*?)\1\)/);
+  if (!firstLocatorMatch) return raw;
+  const simplified = firstLocatorMatch[2].trim();
+  return simplified || raw;
+}
+
+function extractLocatorRaw(lines: string[]): string | undefined {
   const line = lines.find((l) => l.trim().startsWith('Locator:'));
   if (!line) return undefined;
   const raw = line.replace(/^\s*Locator:\s*/, '').trim();
-  return raw ? trimLocator(raw) : undefined;
+  return raw || undefined;
+}
+
+function extractLocator(lines: string[]): string | undefined {
+  const raw = extractLocatorRaw(lines);
+  if (!raw) return undefined;
+  return simplifyLocator(raw);
 }
 
 function extractExpected(lines: string[]): string | undefined {
@@ -189,7 +211,7 @@ function classifyFailureKind(message: string, timeoutMs?: number): FailureStruct
 }
 
 export function buildStructuredFailure(step: ParsedStep): FailureStructured {
-  const raw = step.result.message ?? '';
+  const raw = stripAnsi(step.result.message ?? '');
   const lines = raw.split('\n');
   const url = extractUrlFromStep(step) ?? extractUrlFromMessage(lines);
   const timeout_ms = extractTimeout(lines);
@@ -198,6 +220,7 @@ export function buildStructuredFailure(step: ParsedStep): FailureStructured {
     kind: classifyFailureKind(raw, timeout_ms),
     summary: extractErrorSummary(lines),
     locator: extractLocator(lines),
+    locator_full: extractLocatorRaw(lines),
     url,
     expected: extractExpected(lines),
     actual: extractActual(lines),
@@ -248,10 +271,25 @@ export default class AgentFormatter extends Formatter {
     });
   }
 
-  private createBaseFailurePayload(step: ParsedStep): Pick<FailurePayload, 'error_raw' | 'error_structured'> {
-    const error_raw = step.result.message ?? '';
-    const error_structured = buildStructuredFailure(step);
-    return { error_raw, error_structured };
+  private createBaseFailurePayload(
+    step: ParsedStep,
+  ): Pick<
+    FailurePayload,
+    'error' | 'kind' | 'summary' | 'locator' | 'locator_full' | 'url' | 'expected' | 'actual' | 'timeout_ms'
+  > {
+    const error = stripAnsi(step.result.message ?? '');
+    const errorStructured = buildStructuredFailure(step);
+    return {
+      error,
+      kind: errorStructured.kind,
+      summary: errorStructured.summary,
+      locator: errorStructured.locator,
+      locator_full: errorStructured.locator_full,
+      url: errorStructured.url,
+      expected: errorStructured.expected,
+      actual: errorStructured.actual,
+      timeout_ms: errorStructured.timeout_ms,
+    };
   }
 
   private resolveStoreDbPath(): string | null {
@@ -282,7 +320,10 @@ export default class AgentFormatter extends Formatter {
     step: ParsedStep,
     stepIndex: number,
     baseline: BaselineContext,
-    base: Pick<FailurePayload, 'error_raw' | 'error_structured'>,
+    base: Pick<
+      FailurePayload,
+      'error' | 'kind' | 'summary' | 'locator' | 'locator_full' | 'url' | 'expected' | 'actual' | 'timeout_ms'
+    >,
   ): Promise<FailurePayload> {
     const screenshots = resolveBaselineScreenshots(baseline.artifacts, baseline.artifactDir, stepIndex);
 
@@ -418,13 +459,11 @@ export default class AgentFormatter extends Formatter {
     scenarioId: string | undefined,
     step: ParsedStep,
     idx: number,
-    attempt: number,
   ): Promise<void> {
     const status = normalizeStatus(step.result.status);
     const baseEvent: Record<string, unknown> = {
       event_type: 'step_result',
       scenario_id: scenarioId,
-      attempt,
       step_index: idx,
       keyword: step.keyword,
       text: step.text,
@@ -498,7 +537,7 @@ export default class AgentFormatter extends Formatter {
     const step = parsed.steps[stepIndex];
     if (!step) return;
 
-    await this.emitStepResult(context.scenarioId, step, stepIndex, context.attempt);
+    await this.emitStepResult(context.scenarioId, step, stepIndex);
   }
 
   private handleTestCaseFinished(envelope: Envelope): void {

--- a/packages/cucumber/src/config.ts
+++ b/packages/cucumber/src/config.ts
@@ -6,6 +6,8 @@ export type DebugWorldParametersInput = {
 
 type JsonObject = Record<string, unknown>;
 
+const BUILTIN_AGENT_ENV_VAR_KEYS = ['CODEX_CI', 'CLAUDECODE', 'GEMINI_CLI', 'CURSOR_AGENT'] as const;
+
 function parseJsonObject(raw: string | undefined): JsonObject {
   if (!raw) return {};
 
@@ -27,6 +29,21 @@ export function readCliWorldParameters(argv: string[]): JsonObject {
   if (index < 0) return {};
 
   return parseJsonObject(argv[index + 1]);
+}
+
+function isEnabledEnvVar(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  return normalized !== '0' && normalized !== 'false';
+}
+
+export function isAgentEnvironment(
+  env: Record<string, string | undefined> = process.env,
+  extraEnvVarKeys: string[] = [],
+): boolean {
+  const keys = [...BUILTIN_AGENT_ENV_VAR_KEYS, ...extraEnvVarKeys];
+  return keys.some((key) => isEnabledEnvVar(env[key]));
 }
 
 export function resolveDebugWorldParameters(input: DebugWorldParametersInput = {}): {
@@ -53,4 +70,3 @@ export function resolveDebugWorldParameters(input: DebugWorldParametersInput = {
     },
   };
 }
-

--- a/packages/cucumber/tests/agent.test.ts
+++ b/packages/cucumber/tests/agent.test.ts
@@ -69,6 +69,7 @@ describe('buildStructuredFailure', () => {
     expect(structured.kind).toBe('assertion');
     expect(structured.summary).toBe('element(s) not found');
     expect(structured.locator).toBe('text=/Hi world/i');
+    expect(structured.locator_full).toBe("locator('text=/Hi world/i').first()");
     expect(structured.expected).toBe('visible');
     expect(structured.timeout_ms).toBe(5000);
   });
@@ -85,6 +86,27 @@ describe('buildStructuredFailure', () => {
     expect(structured.kind).toBe('unknown');
     expect(structured.url).toBe('/ok?x=1');
   });
+
+  it('keeps simplified and full locator forms', () => {
+    const step = {
+      keyword: 'Then ',
+      text: 'foo',
+      result: {
+        status: 'FAILED',
+        message: [
+          "Locator: locator('role=button [name=\"Use Item\"i]').or(locator('role=button').filter({ hasText: 'Use Item' })).first()",
+          'Error: element(s) not found',
+        ].join('\n'),
+      },
+      attachments: [],
+    };
+
+    const structured = buildStructuredFailure(step as any);
+    expect(structured.locator).toBe('role=button [name="Use Item"i]');
+    expect(structured.locator_full).toBe(
+      "locator('role=button [name=\"Use Item\"i]').or(locator('role=button').filter({ hasText: 'Use Item' })).first()",
+    );
+  });
 });
 
 describe('agent formatter payload shape', () => {
@@ -98,7 +120,17 @@ describe('agent formatter payload shape', () => {
           {
             keyword: 'Given ',
             text: 'foo',
-            result: { status: 'PASSED', duration: { seconds: 1, nanos: 0 } },
+            result: {
+              status: 'FAILED',
+              duration: { seconds: 1, nanos: 0 },
+              message: [
+                'Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible() failed',
+                "Locator: locator('role=button [name=\"Use Item\"i]').or(locator('role=button')).first()",
+                'Expected: visible',
+                'Timeout: 5000ms',
+                'Error: element(s) not found',
+              ].join('\n'),
+            },
             attachments: [],
           },
         ],
@@ -155,6 +187,19 @@ describe('agent formatter payload shape', () => {
 
     const scenarioEnd = logs.find((entry) => entry.event_type === 'scenario_end');
     expect(scenarioEnd?.will_be_retried).toBeUndefined();
+
+    const stepResult = logs.find((entry) => entry.event_type === 'step_result');
+    const failure = stepResult?.failure as Record<string, unknown> | undefined;
+    expect(failure).toBeDefined();
+    expect(stepResult?.attempt).toBeUndefined();
+    expect(failure?.error).toContain('expect(locator).toBeVisible() failed');
+    expect(String(failure?.error)).not.toContain('\u001b[');
+    expect(failure?.kind).toBe('assertion');
+    expect(failure?.locator).toBe('role=button [name="Use Item"i]');
+    expect(failure?.locator_full).toBe("locator('role=button [name=\"Use Item\"i]').or(locator('role=button')).first()");
+    expect(failure?.summary).toBe('element(s) not found');
+    expect(failure?.error_raw).toBeUndefined();
+    expect(failure?.error_structured).toBeUndefined();
   });
 
   it('emits will_be_retried only when true', async () => {

--- a/packages/cucumber/tests/agent.test.ts
+++ b/packages/cucumber/tests/agent.test.ts
@@ -1,5 +1,50 @@
-import { describe, expect, it } from 'vitest';
-import { buildStructuredFailure } from '../src/agent';
+import { formatterHelpers } from '@cucumber/cucumber';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AgentFormatter, { buildStructuredFailure } from '../src/agent';
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+type AttemptMap = Record<
+  string,
+  {
+    attempt: number;
+    testCase: { testSteps: Array<{ id: string }> };
+    worstTestStepResult: { status: string };
+  }
+>;
+
+function createFormatterHarness(attempts: AttemptMap): {
+  emitter: EventEmitter;
+  logs: Array<Record<string, unknown>>;
+  formatter: AgentFormatter;
+} {
+  const emitter = new EventEmitter();
+  const logs: Array<Record<string, unknown>> = [];
+  const formatter = new AgentFormatter({
+    colorFns: {} as any,
+    cwd: process.cwd(),
+    eventBroadcaster: emitter as any,
+    eventDataCollector: {
+      getTestCaseAttempt: (id: string) => attempts[id],
+    } as any,
+    log: (line: string | Uint8Array) => {
+      const text = typeof line === 'string' ? line : Buffer.from(line).toString('utf8');
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      logs.push(JSON.parse(trimmed) as Record<string, unknown>);
+    },
+    snippetBuilder: {} as any,
+    stream: { write: () => {} } as any,
+    supportCodeLibrary: {} as any,
+    cleanup: async () => {},
+    parsedArgvOptions: {} as any,
+  });
+
+  return { emitter, logs, formatter };
+}
 
 describe('buildStructuredFailure', () => {
   it('extracts playwright-oriented fields from failure message', () => {
@@ -39,5 +84,97 @@ describe('buildStructuredFailure', () => {
     const structured = buildStructuredFailure(step as any);
     expect(structured.kind).toBe('unknown');
     expect(structured.url).toBe('/ok?x=1');
+  });
+});
+
+describe('agent formatter payload shape', () => {
+  let parseSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    parseSpy = vi.spyOn(formatterHelpers, 'parseTestCaseAttempt').mockImplementation(() => {
+      return {
+        testCase: { name: 'Scenario name', sourceLocation: { uri: 'features/a.feature', line: 3 } },
+        testSteps: [
+          {
+            keyword: 'Given ',
+            text: 'foo',
+            result: { status: 'PASSED', duration: { seconds: 1, nanos: 0 } },
+            attachments: [],
+          },
+        ],
+      } as any;
+    });
+  });
+
+  afterEach(() => {
+    parseSpy.mockRestore();
+  });
+
+  it('emits compact fields and keeps run_id only in run_start', async () => {
+    const attempts: AttemptMap = {
+      start1: {
+        attempt: 0,
+        testCase: { testSteps: [{ id: 'step1' }] },
+        worstTestStepResult: { status: 'PASSED' },
+      },
+    };
+    const { emitter, logs, formatter } = createFormatterHarness(attempts);
+
+    emitter.emit('envelope', { testRunStarted: {} });
+    emitter.emit('envelope', { testCaseStarted: { id: 'start1' } });
+    emitter.emit('envelope', {
+      testStepFinished: {
+        testCaseStartedId: 'start1',
+        testStepId: 'step1',
+      },
+    });
+
+    await flushMicrotasks();
+    expect(logs.some((entry) => entry.event_type === 'step_result')).toBe(true);
+
+    emitter.emit('envelope', { testCaseFinished: { testCaseStartedId: 'start1', willBeRetried: false } });
+    emitter.emit('envelope', { testRunFinished: {} });
+
+    await formatter.finished();
+
+    const runStart = logs.find((entry) => entry.event_type === 'run_start');
+    expect(runStart).toBeDefined();
+    expect(runStart?.run_id).toEqual(expect.any(String));
+
+    const nonRunStart = logs.filter((entry) => entry.event_type !== 'run_start');
+    for (const entry of nonRunStart) {
+      expect(entry.run_id).toBeUndefined();
+    }
+
+    for (const entry of logs) {
+      expect(entry.schema_version).toBeUndefined();
+      expect(entry.timestamp).toBeUndefined();
+      expect(entry.event_id).toBeUndefined();
+      expect(entry.sequence).toBeUndefined();
+    }
+
+    const scenarioEnd = logs.find((entry) => entry.event_type === 'scenario_end');
+    expect(scenarioEnd?.will_be_retried).toBeUndefined();
+  });
+
+  it('emits will_be_retried only when true', async () => {
+    const attempts: AttemptMap = {
+      start2: {
+        attempt: 0,
+        testCase: { testSteps: [{ id: 'step1' }] },
+        worstTestStepResult: { status: 'SKIPPED' },
+      },
+    };
+    const { emitter, logs, formatter } = createFormatterHarness(attempts);
+
+    emitter.emit('envelope', { testRunStarted: {} });
+    emitter.emit('envelope', { testCaseStarted: { id: 'start2' } });
+    emitter.emit('envelope', { testCaseFinished: { testCaseStartedId: 'start2', willBeRetried: true } });
+    emitter.emit('envelope', { testRunFinished: {} });
+
+    await formatter.finished();
+
+    const scenarioEnd = logs.find((entry) => entry.event_type === 'scenario_end');
+    expect(scenarioEnd?.will_be_retried).toBe(true);
   });
 });

--- a/packages/cucumber/tests/config.test.ts
+++ b/packages/cucumber/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readCliWorldParameters, resolveDebugWorldParameters } from '../src/config';
+import { isAgentEnvironment, readCliWorldParameters, resolveDebugWorldParameters } from '../src/config';
 
 describe('readCliWorldParameters', () => {
   it('reads inline --world-parameters=JSON', () => {
@@ -50,3 +50,25 @@ describe('resolveDebugWorldParameters', () => {
   });
 });
 
+describe('isAgentEnvironment', () => {
+  it('returns false when no agent env vars are present', () => {
+    expect(isAgentEnvironment({})).toBe(false);
+  });
+
+  it('returns true for known agent env vars', () => {
+    expect(isAgentEnvironment({ CODEX_CI: '1' })).toBe(true);
+    expect(isAgentEnvironment({ CLAUDECODE: '1' })).toBe(true);
+    expect(isAgentEnvironment({ GEMINI_CLI: '1' })).toBe(true);
+    expect(isAgentEnvironment({ CURSOR_AGENT: '1' })).toBe(true);
+  });
+
+  it('accepts extra env var keys', () => {
+    expect(isAgentEnvironment({ FOO_AGENT: '1' }, ['FOO_AGENT'])).toBe(true);
+  });
+
+  it('treats falsey values as disabled', () => {
+    expect(isAgentEnvironment({ CODEX_CI: '' })).toBe(false);
+    expect(isAgentEnvironment({ CODEX_CI: '0' })).toBe(false);
+    expect(isAgentEnvironment({ CODEX_CI: 'false' })).toBe(false);
+  });
+});

--- a/packages/letsrunit/src/setup/cucumber.ts
+++ b/packages/letsrunit/src/setup/cucumber.ts
@@ -4,7 +4,7 @@ import { type Environment, execPm } from '../detect.js';
 
 const BDD_IMPORT = '@letsrunit/cucumber';
 
-const CUCUMBER_CONFIG = `import { resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
+const CUCUMBER_CONFIG = `import { isAgentEnvironment, resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
 
 const { failFast, worldParameters } = resolveDebugWorldParameters({
   argv: process.argv,
@@ -13,9 +13,15 @@ const { failFast, worldParameters } = resolveDebugWorldParameters({
   },
 });
 
+const format = [
+  isAgentEnvironment(process.env)
+    ? '@letsrunit/cucumber/agent'
+    : '@letsrunit/cucumber/progress',
+];
+
 export default {
   require: ['features/support/**/*.js'],
-  format: ['@letsrunit/cucumber/progress'],
+  format,
   failFast,
   plugin: ['@letsrunit/cucumber/store'],
   pluginOptions: {


### PR DESCRIPTION
## Type

Bug fix

## Summary

Make the agent formatter actually stream NDJSON events during execution, and reduce token-heavy payload noise while keeping failure diagnostics useful for agents.

## Changes

- Refactored `@letsrunit/cucumber/agent` to emit from live Cucumber envelopes instead of waiting for `finished()`.
- Removed repeated metadata from events (`schema_version`, `timestamp`, `event_id`, `sequence`) and only emit `run_id` in `run_start`.
- Emit `will_be_retried` only when `true`.
- Simplified failure payload shape by flattening fields under `failure`.
- Renamed `failure.error_raw` to `failure.error` and strip ANSI escape sequences from emitted error text.
- Added both `failure.locator` (simplified) and `failure.locator_full` (exact Playwright chain).
- Removed `attempt` from `step_result` (kept at scenario level).
- Updated cucumber package README and tests accordingly.

## Breaking changes

The NDJSON contract of `@letsrunit/cucumber/agent` changed:

- Removed top-level event fields: `schema_version`, `timestamp`, `event_id`, `sequence`.
- `run_id` now appears only in `run_start`.
- `step_result` no longer includes `attempt`.
- Failure payload changed from nested structured shape to flattened fields.
- `error_raw` was replaced by `error` (ANSI-stripped).
- `locator` no longer includes `{fuzzy}` suffix; `locator_full` was added for the full chain.
