### PR TITLE
feat(playwright): default utility class scrubbing and richer agent failures

### DIFF
--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -124,6 +124,7 @@ Machine-oriented formatter that emits one JSON object per line (NDJSON):
 - `run_id` is emitted only in `run_start`
 - `will_be_retried` is emitted only when `true`
 - Failure events include `failure.error` (ANSI-stripped full message) and flattened fields (`kind`, `summary`, `locator`, `locator_full`, `url`, etc.)
+- When `diff_available` is `false` and a current scrubbed HTML attachment exists, failure events include `failure.html_snapshot`
 - When store plugin data is available, failure events include baseline metadata and inline unified HTML diff
 
 ```js

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -54,6 +54,7 @@ type FailurePayload = {
   expected?: string;
   actual?: string;
   timeout_ms?: number;
+  html_snapshot?: string;
   baseline?: { test_id: string; commit: string | null; screenshots: string[] };
   diff?: string;
   diff_available: boolean;
@@ -387,20 +388,28 @@ export default class AgentFormatter extends Formatter {
     stepIndex: number,
   ): Promise<FailurePayload> {
     const base = this.createBaseFailurePayload(step);
+    const currentHtml = findAttachment(step, 'text/html');
+
+    const withSnapshotWhenNoDiff = (payload: FailurePayload): FailurePayload => {
+      if (!payload.diff_available && currentHtml) {
+        return { ...payload, html_snapshot: currentHtml };
+      }
+      return payload;
+    };
 
     const dbPath = this.resolveStoreDbPath();
-    if (!dbPath) return { ...base, diff_available: false, diff_reason: 'no_store_config' };
+    if (!dbPath) return withSnapshotWhenNoDiff({ ...base, diff_available: false, diff_reason: 'no_store_config' });
 
     if (!scenarioId) {
-      return { ...base, diff_available: false, diff_reason: 'no_baseline' };
+      return withSnapshotWhenNoDiff({ ...base, diff_available: false, diff_reason: 'no_baseline' });
     }
 
     try {
       const baseline = this.loadBaselineContext(dbPath, scenarioId);
-      if (!baseline) return { ...base, diff_available: false, diff_reason: 'no_baseline' };
-      return await this.buildFailureFromBaseline(step, stepIndex, baseline, base);
+      if (!baseline) return withSnapshotWhenNoDiff({ ...base, diff_available: false, diff_reason: 'no_baseline' });
+      return withSnapshotWhenNoDiff(await this.buildFailureFromBaseline(step, stepIndex, baseline, base));
     } catch {
-      return { ...base, diff_available: false, diff_reason: 'diff_compute_failed' };
+      return withSnapshotWhenNoDiff({ ...base, diff_available: false, diff_reason: 'diff_compute_failed' });
     }
   }
 

--- a/packages/cucumber/tests/agent.test.ts
+++ b/packages/cucumber/tests/agent.test.ts
@@ -131,7 +131,7 @@ describe('agent formatter payload shape', () => {
                 'Error: element(s) not found',
               ].join('\n'),
             },
-            attachments: [],
+            attachments: [{ mediaType: 'text/html', body: '<html><body><div>snapshot</div></body></html>' }],
           },
         ],
       } as any;
@@ -198,6 +198,7 @@ describe('agent formatter payload shape', () => {
     expect(failure?.locator).toBe('role=button [name="Use Item"i]');
     expect(failure?.locator_full).toBe("locator('role=button [name=\"Use Item\"i]').or(locator('role=button')).first()");
     expect(failure?.summary).toBe('element(s) not found');
+    expect(failure?.html_snapshot).toBe('<html><body><div>snapshot</div></body></html>');
     expect(failure?.error_raw).toBeUndefined();
     expect(failure?.error_structured).toBeUndefined();
   });

--- a/packages/playwright/src/scrub-html.ts
+++ b/packages/playwright/src/scrub-html.ts
@@ -32,7 +32,7 @@ export type ScrubHtmlOptions = {
   /** Limit lists to max items: -1 mean no limit. Default: -1 */
   limitLists?: number;
   /** Strip utility-framework classes (Tailwind, Bootstrap, UnoCSS, Windi) from class
-   *  attributes. Removes the attribute entirely when all classes are stripped. Default: false */
+   *  attributes. Removes the attribute entirely when all classes are stripped. Default: true */
   dropUtilityClasses?: boolean;
 };
 
@@ -51,7 +51,7 @@ function getDefaults(contentLength: number): Required<ScrubHtmlOptions> {
     dropComments: true,
     replaceBrInHeadings: true,
     limitLists: contentLength >= HTML_LIMIT_LISTS_THRESHOLD ? 20 : -1,
-    dropUtilityClasses: false,
+    dropUtilityClasses: true,
   };
 }
 
@@ -350,10 +350,25 @@ const UTILITY_STANDALONE = new Set([
   'sr-only', 'not-sr-only', 'clearfix', 'row', 'col',
 ]);
 
+const SPACING_ALPHA_VALUES = new Set(['auto', 'px']);
+
+function isSpacingUtility(token: string): boolean {
+  const match = token.match(/^-?([mp][xytblrse]?)-(.*)$/i);
+  if (!match) return false;
+
+  const value = match[2];
+  if (!value) return false;
+
+  if (/^[0-9./[\]-]+$/.test(value)) return true;
+  if (SPACING_ALPHA_VALUES.has(value.toLowerCase())) return true;
+  return false;
+}
+
 function isUtilityClass(token: string): boolean {
   if (UTILITY_VARIANT_RE.test(token)) return true;
   const base = token.startsWith('-') ? token.slice(1) : token;
   if (UTILITY_STANDALONE.has(base)) return true;
+  if (/^-?[mp][xytblrse]?-/i.test(token)) return isSpacingUtility(token);
   return UTILITY_PREFIX_RE.test(token);
 }
 

--- a/packages/playwright/src/snapshot.ts
+++ b/packages/playwright/src/snapshot.ts
@@ -6,7 +6,7 @@ import type { Snapshot } from './types';
 import { waitForDomIdle } from './wait';
 
 export type SnapshotOptions = {
-  /** Strip utility-framework classes (Tailwind, Bootstrap, UnoCSS, Windi) from the captured HTML. */
+  /** Strip utility-framework classes (Tailwind, Bootstrap, UnoCSS, Windi) from the captured HTML. Default: true. */
   dropUtilityClasses?: boolean;
 };
 
@@ -16,7 +16,9 @@ export async function snapshot(page: Page, opts: SnapshotOptions = {}): Promise<
 
   const [url, html, file] = await Promise.all([page.url(), getContentWithMarkedHidden(page), screenshot(page)]);
 
-  const finalHtml = opts.dropUtilityClasses
+  const dropUtilityClasses = opts.dropUtilityClasses ?? true;
+
+  const finalHtml = dropUtilityClasses
     ? await realScrubHtml({ html, url }, {
         dropHidden: false, dropHead: false, dropSvg: false, pickMain: false,
         stripAttributes: 0, normalizeWhitespace: false, dropComments: false,

--- a/packages/playwright/tests/scrub-html.test.ts
+++ b/packages/playwright/tests/scrub-html.test.ts
@@ -273,10 +273,10 @@ describe('dropUtilityClasses', () => {
     expect(out).toContain('class="card is-open"');
   });
 
-  it('is disabled by default and leaves class attributes unchanged', async () => {
+  it('is enabled by default and strips utility classes', async () => {
     const html = '<div class="flex p-4 my-component">x</div>';
     const out = await realScrubHtml(page(html));
-    expect(out).toContain('class="flex p-4 my-component"');
+    expect(out).toContain('class="my-component"');
   });
 });
 

--- a/packages/playwright/tests/snapshot.test.ts
+++ b/packages/playwright/tests/snapshot.test.ts
@@ -109,6 +109,20 @@ describe('snapshot', () => {
     expect(result.html).toContain('card');
   });
 
+  it('strips utility classes from html by default', async () => {
+    const page = makePage({
+      content: vi.fn().mockResolvedValue(
+        '<html><body><div class="flex p-4 card">Hello</div></body></html>',
+      ),
+    });
+
+    const result = await snapshot(page);
+
+    expect(result.html).not.toMatch(/\bflex\b/);
+    expect(result.html).not.toMatch(/\bp-4\b/);
+    expect(result.html).toContain('card');
+  });
+
   it('executes aria-hidden marking callback and undo with real DOM elements', async () => {
     // Add elements to jsdom so the walk/isHidden code paths are exercised
     const visible = document.createElement('div');


### PR DESCRIPTION
## Type

Feature

## Summary

Improve default HTML scrubbing quality across playwright utilities and improve agent failure diagnostics by including a scrubbed HTML snapshot when baseline diffing is unavailable.

## Changes

- Enabled utility-class scrubbing by default in `realScrubHtml`.
- Enabled utility-class scrubbing by default in `snapshot()` unless explicitly disabled.
- Tightened utility-class detection so semantic kebab-case classes like `my-component` are not incorrectly stripped.
- Added `failure.html_snapshot` in `@letsrunit/cucumber/agent` when `diff_available` is `false` and current scrubbed HTML is available.
- Updated tests for scrub/snapshot defaults and agent failure payload behavior.

## Breaking changes

- `snapshot()` now strips utility-framework classes by default unless `dropUtilityClasses: false` is provided.
- `realScrubHtml()` now strips utility-framework classes by default unless `dropUtilityClasses: false` is provided.