### PR TITLE
Log unexpected errors in cucumber reporter

### DIFF
--- a/packages/cucumber/src/after-step-artifacts.ts
+++ b/packages/cucumber/src/after-step-artifacts.ts
@@ -1,0 +1,56 @@
+import type { ICreateAttachment } from '@cucumber/cucumber';
+import { type Page } from '@playwright/test';
+import { scrubHtml } from '@letsrunit/playwright';
+import { logUnexpectedError } from './unexpected-error-log';
+
+type AfterStepWorld = {
+  page?: Page;
+  attach: ICreateAttachment;
+};
+
+type CaptureDeps = {
+  scrubHtmlFn?: typeof scrubHtml;
+  logUnexpectedErrorFn?: typeof logUnexpectedError;
+};
+
+function resolvePageUrl(page: Page): string | null {
+  try {
+    return page.url();
+  } catch {
+    return null;
+  }
+}
+
+export async function captureAfterStepArtifacts(world: AfterStepWorld, deps: CaptureDeps = {}): Promise<void> {
+  const page = world.page;
+  if (!page) return;
+
+  const url = resolvePageUrl(page);
+  if (!url || url === 'about:blank') return;
+
+  const scrubHtmlFn = deps.scrubHtmlFn ?? scrubHtml;
+  const logUnexpectedErrorFn = deps.logUnexpectedErrorFn ?? logUnexpectedError;
+
+  let screenshot: Buffer | null = null;
+  let html: string | null = null;
+
+  try {
+    screenshot = await page.screenshot();
+  } catch (error) {
+    await logUnexpectedErrorFn('cucumber.after_step.capture.screenshot', error, { url });
+  }
+
+  try {
+    html = await scrubHtmlFn(page);
+  } catch (error) {
+    await logUnexpectedErrorFn('cucumber.after_step.capture.scrub_html', error, { url });
+  }
+
+  try {
+    await world.attach(url, 'text/x-letsrunit-url');
+    if (screenshot) await world.attach(screenshot, 'image/png');
+    if (html) await world.attach(html, 'text/html');
+  } catch (error) {
+    await logUnexpectedErrorFn('cucumber.after_step.capture.attach', error, { url });
+  }
+}

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -388,11 +388,11 @@ export default class AgentFormatter extends Formatter {
     stepIndex: number,
   ): Promise<FailurePayload> {
     const base = this.createBaseFailurePayload(step);
-    const currentHtml = findAttachment(step, 'text/html');
+    const htmlSnapshot = findAttachment(step, 'text/html');
 
     const withSnapshotWhenNoDiff = (payload: FailurePayload): FailurePayload => {
-      if (!payload.diff_available && currentHtml) {
-        return { ...payload, html_snapshot: currentHtml };
+      if (!payload.diff_available && htmlSnapshot) {
+        return { ...payload, html_snapshot: htmlSnapshot };
       }
       return payload;
     };

--- a/packages/cucumber/src/index.ts
+++ b/packages/cucumber/src/index.ts
@@ -1,8 +1,9 @@
 import { After, AfterStep, Before, BeforeAll, defineParameterType, Given, Then, When } from '@cucumber/cucumber';
 import { registry, typeDefinitions } from '@letsrunit/bdd'; // importing bdd registers built-in steps as a side effect
 import { sanitizeStepDefinition } from '@letsrunit/gherkin';
-import { browse, createDateEngine, createFieldEngine, scrubHtml } from '@letsrunit/playwright';
+import { browse, createDateEngine, createFieldEngine } from '@letsrunit/playwright';
 import { chromium, selectors } from '@playwright/test';
+import { captureAfterStepArtifacts } from './after-step-artifacts';
 import { resolveHeadless, shouldKeepBrowserOpenOnFailure } from './run-policy';
 
 for (const type of typeDefinitions) {
@@ -38,17 +39,5 @@ After({ name: 'Close browser session' }, async function ({ result }: { result?: 
 });
 
 AfterStep(async function () {
-  const page = this.page;
-  if (!page || page.url() === 'about:blank') return;
-
-  try {
-    const [screenshot, html] = await Promise.all([
-      page.screenshot().catch(() => null),
-      scrubHtml(page).catch(() => null),
-    ]);
-
-    this.attach(page.url(), 'text/x-letsrunit-url');
-    if (screenshot) this.attach(screenshot, 'image/png');
-    if (html) this.attach(html, 'text/html');
-  } catch {}
+  await captureAfterStepArtifacts(this);
 });

--- a/packages/cucumber/src/store-config.ts
+++ b/packages/cucumber/src/store-config.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 const DEFAULT_DIR = '.letsrunit';
 
 let configuredDbPath: string | undefined;
+let configuredRunId: string | undefined;
 
 export function setConfiguredStoreDirectory(directory?: string): void {
   const root = directory ?? DEFAULT_DIR;
@@ -11,8 +12,17 @@ export function setConfiguredStoreDirectory(directory?: string): void {
 
 export function clearConfiguredStoreDirectory(): void {
   configuredDbPath = undefined;
+  configuredRunId = undefined;
 }
 
 export function getConfiguredStoreDbPath(): string | undefined {
   return configuredDbPath;
+}
+
+export function setConfiguredRunId(runId: string): void {
+  configuredRunId = runId;
+}
+
+export function getConfiguredRunId(): string | undefined {
+  return configuredRunId;
 }

--- a/packages/cucumber/src/store.ts
+++ b/packages/cucumber/src/store.ts
@@ -23,7 +23,7 @@ import { existsSync, mkdirSync, statSync } from 'node:fs';
 import { utimes, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
-import { setConfiguredStoreDirectory } from './store-config';
+import { setConfiguredRunId, setConfiguredStoreDirectory } from './store-config';
 
 const DEFAULT_DIR = '.letsrunit';
 
@@ -262,6 +262,7 @@ function createRecorderContext(directory?: string): RecorderContext {
     }).trim();
   } catch {}
   insertRun(db, runId, gitCommit, Date.now());
+  setConfiguredRunId(runId);
 
   return {
     db,

--- a/packages/cucumber/src/unexpected-error-log.ts
+++ b/packages/cucumber/src/unexpected-error-log.ts
@@ -1,0 +1,49 @@
+import { mkdir, appendFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getConfiguredRunId, getConfiguredStoreDbPath } from './store-config';
+
+const DEFAULT_STORE_DIR = '.letsrunit';
+const FALLBACK_RUN_ID = 'unknown-run';
+
+type UnexpectedErrorMeta = Record<string, unknown>;
+
+function toErrorText(error: unknown): string {
+  if (error instanceof Error) return error.stack ?? error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function resolveStoreDir(): string {
+  const dbPath = getConfiguredStoreDbPath();
+  if (!dbPath) return DEFAULT_STORE_DIR;
+  return dirname(dbPath);
+}
+
+function formatMeta(meta?: UnexpectedErrorMeta): string {
+  if (!meta) return '';
+  const lines = Object.entries(meta).map(([key, value]) => `${key}: ${String(value)}`);
+  return lines.join('\n');
+}
+
+export async function logUnexpectedError(source: string, error: unknown, meta?: UnexpectedErrorMeta): Promise<void> {
+  try {
+    const dir = resolveStoreDir();
+    const runId = getConfiguredRunId() ?? FALLBACK_RUN_ID;
+    await mkdir(dir, { recursive: true });
+
+    const sections = [
+      `[${new Date().toISOString()}]`,
+      `source: ${source}`,
+      formatMeta(meta),
+      'error:',
+      toErrorText(error),
+      '',
+    ].filter((part) => part.length > 0);
+
+    await appendFile(join(dir, `${runId}.errors.log`), `${sections.join('\n')}\n`, 'utf8');
+  } catch {}
+}

--- a/packages/cucumber/tests/after-step-artifacts.test.ts
+++ b/packages/cucumber/tests/after-step-artifacts.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureAfterStepArtifacts } from '../src/after-step-artifacts';
+import { clearConfiguredStoreDirectory, setConfiguredRunId, setConfiguredStoreDirectory } from '../src/store-config';
+import { logUnexpectedError } from '../src/unexpected-error-log';
+
+describe('unexpected error logging', () => {
+  afterEach(() => {
+    clearConfiguredStoreDirectory();
+  });
+
+  it('writes {run_id}.errors.log in configured letsrunitStore directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'letsrunit-cucumber-errors-'));
+    setConfiguredStoreDirectory(dir);
+    setConfiguredRunId('run-abc');
+
+    await logUnexpectedError('cucumber.after_step.capture.scrub_html', new Error('scrub failed'), { url: '/transfer' });
+
+    const path = join(dir, 'run-abc.errors.log');
+    const content = await readFile(path, 'utf8');
+
+    expect(content).toContain('source: cucumber.after_step.capture.scrub_html');
+    expect(content).toContain('url: /transfer');
+    expect(content).toContain('error:');
+    expect(content).toContain('scrub failed');
+  });
+});
+
+describe('captureAfterStepArtifacts', () => {
+  afterEach(() => {
+    clearConfiguredStoreDirectory();
+  });
+
+  it('logs scrub errors and still attaches url and screenshot', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'letsrunit-cucumber-artifacts-'));
+    setConfiguredStoreDirectory(dir);
+    setConfiguredRunId('run-scrub-fail');
+
+    const attach = vi.fn(async () => {});
+    const page = {
+      url: () => 'https://example.com/transfer',
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
+    };
+
+    const failingScrub = vi.fn(async () => {
+      throw new Error('scrub exploded');
+    });
+
+    await captureAfterStepArtifacts({ page: page as any, attach }, { scrubHtmlFn: failingScrub as any });
+
+    expect(attach).toHaveBeenCalledWith('https://example.com/transfer', 'text/x-letsrunit-url');
+    expect(attach).toHaveBeenCalledWith(Buffer.from('png'), 'image/png');
+    expect(attach).not.toHaveBeenCalledWith(expect.any(String), 'text/html');
+
+    const logPath = join(dir, 'run-scrub-fail.errors.log');
+    const content = await readFile(logPath, 'utf8');
+    expect(content).toContain('source: cucumber.after_step.capture.scrub_html');
+    expect(content).toContain('scrub exploded');
+  });
+
+  it('does not create an error log when no unexpected errors occur', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'letsrunit-cucumber-clean-run-'));
+    setConfiguredStoreDirectory(dir);
+    setConfiguredRunId('run-no-errors');
+
+    const attach = vi.fn(async () => {});
+    const page = {
+      url: () => 'https://example.com/ok',
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
+    };
+    const successfulScrub = vi.fn(async () => '<main>ok</main>');
+
+    await captureAfterStepArtifacts({ page: page as any, attach }, { scrubHtmlFn: successfulScrub as any });
+
+    expect(attach).toHaveBeenCalledWith('https://example.com/ok', 'text/x-letsrunit-url');
+    expect(attach).toHaveBeenCalledWith(Buffer.from('png'), 'image/png');
+    expect(attach).toHaveBeenCalledWith('<main>ok</main>', 'text/html');
+    expect(existsSync(join(dir, 'run-no-errors.errors.log'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Type

Fix

## Summary

Log unexpected errors when gathering attachments in cucumber reporter on disk.

## Changes

Instead of silently ignoring errors when taking a snapshot or screenshot, log them to disk in the `.letsrunit` project folder.
