### PR TITLE
fix: handle SVG className in utility class stripping

### DIFF
--- a/packages/playwright/src/scrub-html.ts
+++ b/packages/playwright/src/scrub-html.ts
@@ -373,10 +373,10 @@ function isUtilityClass(token: string): boolean {
 }
 
 function stripUtilityClasses(doc: Document) {
-  for (const el of doc.body.querySelectorAll<HTMLElement>('[class]')) {
-    const kept = el.className.split(/\s+/).filter((t) => t && !isUtilityClass(t));
+  for (const el of doc.body.querySelectorAll<Element>('[class]')) {
+    const kept = [...el.classList].filter((t) => t && !isUtilityClass(t));
     if (kept.length === 0) el.removeAttribute('class');
-    else el.className = kept.join(' ');
+    else el.setAttribute('class', kept.join(' '));
   }
 }
 

--- a/packages/playwright/tests/scrub-html.test.ts
+++ b/packages/playwright/tests/scrub-html.test.ts
@@ -278,6 +278,15 @@ describe('dropUtilityClasses', () => {
     const out = await realScrubHtml(page(html));
     expect(out).toContain('class="my-component"');
   });
+
+  it('handles svg className values and strips utility classes without throwing', async () => {
+    const html = '<svg class="lucide lucide-menu w-4 h-4"><circle cx="10" cy="10" r="5" /></svg>';
+    const out = await realScrubHtml(page(html), { dropUtilityClasses: true });
+
+    expect(out).toContain('class="lucide lucide-menu"');
+    expect(out).not.toContain('w-4');
+    expect(out).not.toContain('h-4');
+  });
 });
 
 describe('scrubHtml (Page overload)', () => {


### PR DESCRIPTION
## Type

Bug fix

## Summary

Fixes HTML scrubbing crashes on pages containing SVG elements by avoiding string-only `className` handling when removing utility classes.

## Changes

- Updated `stripUtilityClasses` in `@letsrunit/playwright` to tokenize classes via `classList` and set the final `class` attribute explicitly.
- Added a regression test covering an SVG element with mixed semantic and utility classes.
- Verified targeted tests pass: `yarn test --project @letsrunit/playwright packages/playwright/tests/scrub-html.test.ts`.
- Ran full suite before PR: `yarn test` (currently one unrelated existing failure in `@letsrunit/bdd tests/steps/index.test.ts`: timeout in `registers built-in step definitions when imported`).

## Breaking changes

None.