### PR TITLE
fix: ordered fallback locator and {fuzzy} reporter contract

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.letsrunit]
+command = "node_modules/.bin/tsx"
+args = ["packages/mcp-server/src/index.ts"]
+
+[mcp_servers.letsrunit.env]
+LETSRUNIT_MCP_RUNTIME_MODE = "standalone"

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "letsrunit": {
       "command": "node_modules/.bin/tsx",
-      "args": ["packages/mcp-server/src/index.ts"]
+      "args": ["packages/mcp-server/src/index.ts"],
+      "env": {
+        "LETSRUNIT_MCP_RUNTIME_MODE": "standalone"
+      }
     }
   }
 }

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -138,10 +138,12 @@ function stripAnsi(input: string): string {
 
 function simplifyLocator(locator: string): string {
   const raw = locator.trim();
-  const firstLocatorMatch = raw.match(/locator\((['"`])([\s\S]*?)\1\)/);
-  if (!firstLocatorMatch) return raw;
+  const withoutMarker = raw.replace(/\s*\{fuzzy\}\s*$/i, '').trim();
+
+  const firstLocatorMatch = withoutMarker.match(/locator\((['"`])([\s\S]*?)\1\)/);
+  if (!firstLocatorMatch) return withoutMarker;
   const simplified = firstLocatorMatch[2].trim();
-  return simplified || raw;
+  return simplified || withoutMarker;
 }
 
 function extractLocatorRaw(lines: string[]): string | undefined {

--- a/packages/cucumber/src/progress.ts
+++ b/packages/cucumber/src/progress.ts
@@ -105,15 +105,18 @@ function resolveLastPassedLine({ scenarioId }: { scenarioId: string }): LastPass
   }
 }
 
+function extractPrimaryLocator(raw: string): string {
+  const withoutMarker = raw.replace(/\s*\{fuzzy\}\s*$/i, '').trim();
+
+  const firstLocatorMatch = withoutMarker.match(/locator\((['"`])([\s\S]*?)\1\)/);
+  if (!firstLocatorMatch) return withoutMarker;
+  return firstLocatorMatch[2].trim() || withoutMarker;
+}
+
 function simplifyLocator(locator: string): { locator: string; fuzzy: boolean } {
   const raw = locator.trim();
-  const fuzzy = raw.includes('.or(');
-
-  const firstLocatorMatch = raw.match(/locator\((['"`])([\s\S]*?)\1\)/);
-  if (!firstLocatorMatch) return { locator: raw, fuzzy };
-
-  const simplified = firstLocatorMatch[2].trim();
-  return { locator: simplified || raw, fuzzy };
+  const fuzzy = raw.includes('{fuzzy}');
+  return { locator: extractPrimaryLocator(raw), fuzzy };
 }
 
 function isStackLine(line: string): boolean {

--- a/packages/cucumber/tests/agent.test.ts
+++ b/packages/cucumber/tests/agent.test.ts
@@ -94,7 +94,7 @@ describe('buildStructuredFailure', () => {
       result: {
         status: 'FAILED',
         message: [
-          "Locator: locator('role=button [name=\"Use Item\"i]').or(locator('role=button').filter({ hasText: 'Use Item' })).first()",
+          "Locator: locator('role=button [name=\"Use Item\"i]') {fuzzy}",
           'Error: element(s) not found',
         ].join('\n'),
       },
@@ -103,9 +103,7 @@ describe('buildStructuredFailure', () => {
 
     const structured = buildStructuredFailure(step as any);
     expect(structured.locator).toBe('role=button [name="Use Item"i]');
-    expect(structured.locator_full).toBe(
-      "locator('role=button [name=\"Use Item\"i]').or(locator('role=button').filter({ hasText: 'Use Item' })).first()",
-    );
+    expect(structured.locator_full).toBe("locator('role=button [name=\"Use Item\"i]') {fuzzy}");
   });
 });
 
@@ -125,7 +123,7 @@ describe('agent formatter payload shape', () => {
               duration: { seconds: 1, nanos: 0 },
               message: [
                 'Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible() failed',
-                "Locator: locator('role=button [name=\"Use Item\"i]').or(locator('role=button')).first()",
+                "Locator: locator('role=button [name=\"Use Item\"i]') {fuzzy}",
                 'Expected: visible',
                 'Timeout: 5000ms',
                 'Error: element(s) not found',
@@ -196,7 +194,7 @@ describe('agent formatter payload shape', () => {
     expect(String(failure?.error)).not.toContain('\u001b[');
     expect(failure?.kind).toBe('assertion');
     expect(failure?.locator).toBe('role=button [name="Use Item"i]');
-    expect(failure?.locator_full).toBe("locator('role=button [name=\"Use Item\"i]').or(locator('role=button')).first()");
+    expect(failure?.locator_full).toBe("locator('role=button [name=\"Use Item\"i]') {fuzzy}");
     expect(failure?.summary).toBe('element(s) not found');
     expect(failure?.html_snapshot).toBe('<html><body><div>snapshot</div></body></html>');
     expect(failure?.error_raw).toBeUndefined();

--- a/packages/cucumber/tests/progress.test.ts
+++ b/packages/cucumber/tests/progress.test.ts
@@ -25,15 +25,26 @@ describe('extractFailureDetails', () => {
     expect(details.url).toBeUndefined();
   });
 
-  it('simplifies fuzzy locator chains and marks them as fuzzy', () => {
+  it('detects {fuzzy} marker and keeps primary locator', () => {
     const message = [
-      "Locator: locator('role=button [name=\"Use Item\"i]').or(locator('role=button').filter({ hasText: 'Use Item' })).or(locator('text=Use Item').locator('..').locator('role=button')).first()",
+      "Locator: locator('role=button [name=\"Use Item\"i]') {fuzzy}",
       'Error: element(s) not found',
     ].join('\n');
 
     const details = extractFailureDetails(message);
     expect(details.locator).toBe('role=button [name="Use Item"i]');
     expect(details.locatorFuzzy).toBe(true);
+  });
+
+  it('does not mark fuzzy when marker is absent', () => {
+    const message = [
+      "Locator: locator('role=link[name=\"Bekijk voorbeeld\"]').or(locator('role=link').filter({ hasText: 'Bekijk voorbeeld' })).first()",
+      'Error: element(s) not found',
+    ].join('\n');
+
+    const details = extractFailureDetails(message);
+    expect(details.locator).toBe('role=link[name="Bekijk voorbeeld"]');
+    expect(details.locatorFuzzy).toBe(false);
   });
 
   it('falls back to first useful line for non-Playwright message', () => {

--- a/packages/playwright/src/fallback-locator.ts
+++ b/packages/playwright/src/fallback-locator.ts
@@ -1,6 +1,7 @@
 import { Locator } from '@playwright/test';
 
 type LocatorMethod = (...args: any[]) => any;
+type ProxyProperty = string | symbol;
 
 const ACTION_METHODS = new Set([
   'blur',
@@ -73,36 +74,94 @@ function withNoWaitTimeout(method: string, args: unknown[]): unknown[] {
   return next;
 }
 
+function handleExpect(primary: Locator, candidates: Locator[]) {
+  return (expression: string, options: unknown) => {
+    if (expression.includes('to.be.visible') || expression.includes('to.be.attached')) {
+      return (buildOrLocator(candidates) as any)._expect(expression, options);
+    }
+    return (primary as any)._expect(expression, options);
+  };
+}
+
+function handleAll(candidates: Locator[]) {
+  return async () => {
+    const all: Locator[] = [];
+    for (const candidate of candidates) {
+      all.push(...(await candidate.all()));
+    }
+    return all;
+  };
+}
+
+function handleLocatorChain(prop: string, candidates: Locator[]) {
+  return (...args: any[]) =>
+    createFallbackLocator(
+      candidates.map((candidate) => {
+        const method = (candidate as any)[prop] as LocatorMethod;
+        return method.apply(candidate, args);
+      }),
+    );
+}
+
+function handleCount(primary: Locator, candidates: Locator[]) {
+  return async () => {
+    const primaryCount = await primary.count();
+    if (primaryCount > 0) return primaryCount;
+
+    const fallback = await firstPresentFallback(candidates);
+    if (!fallback) return primaryCount;
+
+    return fallback.count();
+  };
+}
+
+function handleAction(prop: string, primary: Locator, candidates: Locator[], primaryMethod: LocatorMethod) {
+  return async (...args: any[]) => {
+    try {
+      return await primaryMethod.apply(primary, args);
+    } catch (error) {
+      const fallback = await firstPresentFallback(candidates);
+      if (!fallback) throw error;
+      const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
+      return fallbackMethod.apply(fallback, withNoWaitTimeout(prop, args));
+    }
+  };
+}
+
+function handleAsyncFallback(prop: string, primaryMethod: LocatorMethod, primary: Locator, candidates: Locator[]) {
+  return (...args: any[]) => {
+    const result = primaryMethod.apply(primary, args);
+    if (!result || typeof result !== 'object' || typeof (result as Promise<unknown>).catch !== 'function') {
+      return result;
+    }
+
+    return (result as Promise<unknown>).catch(async (error: unknown) => {
+      const fallback = await firstPresentFallback(candidates);
+      if (!fallback) throw error;
+      const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
+      return fallbackMethod.apply(fallback, args);
+    });
+  };
+}
+
 export function createFallbackLocator(candidates: Locator[]): Locator {
   const primary = candidates[0];
   const unsupported = new Set(['filter', 'getByRole', 'getByLabel']);
 
   const proxy = new Proxy(primary as unknown as object, {
-    get(_target, prop) {
-      if (prop === 'toString') {
-        return () => `FallbackLocator(${candidates.map((candidate) => candidate.toString()).join(' -> ')})`;
-      }
-
-      if (prop === 'all') {
-        return async () => {
-          const all: Locator[] = [];
-          for (const candidate of candidates) {
-            all.push(...(await candidate.all()));
-          }
-          return all;
-        };
-      }
-
-      if (prop === '_expect') {
-        return (expression: string, options: unknown) => {
-          if (expression.includes('to.be.visible') || expression.includes('to.be.attached')) {
-            return (buildOrLocator(candidates) as any)._expect(expression, options);
-          }
-          return (primary as any)._expect(expression, options);
-        };
-      }
-
+    get(_target, prop: ProxyProperty) {
       if (typeof prop !== 'string') return (primary as any)[prop];
+
+      switch (prop) {
+        case 'toString':
+          return () => `FallbackLocator(${candidates.map((candidate) => candidate.toString()).join(' -> ')})`;
+        case 'all':
+          return handleAll(candidates);
+        case '_expect':
+          return handleExpect(primary, candidates);
+        case 'count':
+          return handleCount(primary, candidates);
+      }
 
       if (unsupported.has(prop)) {
         return () => {
@@ -111,54 +170,17 @@ export function createFallbackLocator(candidates: Locator[]): Locator {
       }
 
       if (LOCATOR_CHAIN_METHODS.has(prop)) {
-        return (...args: any[]) =>
-          createFallbackLocator(
-            candidates.map((candidate) => {
-              const method = (candidate as any)[prop] as LocatorMethod;
-              return method.apply(candidate, args);
-            }),
-          );
-      }
-
-      if (prop === 'count') {
-        return async (...args: any[]) => {
-          const primaryCount = await primary.count(...args);
-          if (primaryCount > 0) return primaryCount;
-          const fallback = await firstPresentFallback(candidates);
-          if (!fallback) return primaryCount;
-          return fallback.count(...args);
-        };
+        return handleLocatorChain(prop, candidates);
       }
 
       const primaryMethod = (primary as any)[prop] as LocatorMethod;
       if (typeof primaryMethod !== 'function') return primaryMethod;
 
       if (ACTION_METHODS.has(prop)) {
-        return async (...args: any[]) => {
-          try {
-            return await primaryMethod.apply(primary, args);
-          } catch (error) {
-            const fallback = await firstPresentFallback(candidates);
-            if (!fallback) throw error;
-            const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
-            return fallbackMethod.apply(fallback, withNoWaitTimeout(prop, args));
-          }
-        };
+        return handleAction(prop, primary, candidates, primaryMethod);
       }
 
-      return (...args: any[]) => {
-        const result = primaryMethod.apply(primary, args);
-        if (!result || typeof result !== 'object' || typeof (result as Promise<unknown>).catch !== 'function') {
-          return result;
-        }
-
-        return (result as Promise<unknown>).catch(async (error: unknown) => {
-          const fallback = await firstPresentFallback(candidates);
-          if (!fallback) throw error;
-          const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
-          return fallbackMethod.apply(fallback, args);
-        });
-      };
+      return handleAsyncFallback(prop, primaryMethod, primary, candidates);
     },
   });
 

--- a/packages/playwright/src/fallback-locator.ts
+++ b/packages/playwright/src/fallback-locator.ts
@@ -144,6 +144,13 @@ function handleAsyncFallback(prop: string, primaryMethod: LocatorMethod, primary
   };
 }
 
+function formatLocatorChain(candidates: Locator[]): string {
+  const parts = candidates.map((candidate) => candidate.toString());
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0];
+  return `${parts[0]} {fuzzy}`;
+}
+
 export function createFallbackLocator(candidates: Locator[]): Locator {
   const primary = candidates[0];
   const unsupported = new Set(['filter', 'getByRole', 'getByLabel']);
@@ -154,7 +161,7 @@ export function createFallbackLocator(candidates: Locator[]): Locator {
 
       switch (prop) {
         case 'toString':
-          return () => `FallbackLocator(${candidates.map((candidate) => candidate.toString()).join(' -> ')})`;
+          return () => formatLocatorChain(candidates);
         case 'all':
           return handleAll(candidates);
         case '_expect':

--- a/packages/playwright/src/fallback-locator.ts
+++ b/packages/playwright/src/fallback-locator.ts
@@ -1,0 +1,166 @@
+import { Locator } from '@playwright/test';
+
+type LocatorMethod = (...args: any[]) => any;
+
+const ACTION_METHODS = new Set([
+  'blur',
+  'check',
+  'clear',
+  'click',
+  'dblclick',
+  'dispatchEvent',
+  'dragTo',
+  'fill',
+  'focus',
+  'hover',
+  'press',
+  'pressSequentially',
+  'scrollIntoViewIfNeeded',
+  'selectOption',
+  'setChecked',
+  'setInputFiles',
+  'tap',
+  'type',
+  'uncheck',
+]);
+
+const LOCATOR_CHAIN_METHODS = new Set([
+  'and',
+  'first',
+  'last',
+  'locator',
+  'nth',
+  'or',
+]);
+
+const NO_WAIT_OPTION_INDEX: Record<string, number> = {
+  dragTo: 1,
+  fill: 1,
+  press: 1,
+  pressSequentially: 1,
+  selectOption: 1,
+  setInputFiles: 1,
+  type: 1,
+};
+
+function buildOrLocator(candidates: Locator[]): Locator {
+  let result = candidates[0];
+  for (const candidate of candidates.slice(1)) {
+    result = result.or(candidate);
+  }
+  return result;
+}
+
+async function firstPresentFallback(candidates: Locator[]): Promise<Locator | null> {
+  for (const candidate of candidates.slice(1)) {
+    try {
+      if ((await candidate.count()) > 0) return candidate;
+    } catch {}
+  }
+  return null;
+}
+
+function withNoWaitTimeout(method: string, args: unknown[]): unknown[] {
+  const next = [...args];
+  const optionIndex = NO_WAIT_OPTION_INDEX[method] ?? 0;
+  const current = next[optionIndex];
+
+  if (current && typeof current === 'object') {
+    next[optionIndex] = { ...(current as Record<string, unknown>), timeout: 0 };
+  } else {
+    next[optionIndex] = { timeout: 0 };
+  }
+  return next;
+}
+
+export function createFallbackLocator(candidates: Locator[]): Locator {
+  const primary = candidates[0];
+  const unsupported = new Set(['filter', 'getByRole', 'getByLabel']);
+
+  const proxy = new Proxy(primary as unknown as object, {
+    get(_target, prop) {
+      if (prop === 'toString') {
+        return () => `FallbackLocator(${candidates.map((candidate) => candidate.toString()).join(' -> ')})`;
+      }
+
+      if (prop === 'all') {
+        return async () => {
+          const all: Locator[] = [];
+          for (const candidate of candidates) {
+            all.push(...(await candidate.all()));
+          }
+          return all;
+        };
+      }
+
+      if (prop === '_expect') {
+        return (expression: string, options: unknown) => {
+          if (expression.includes('to.be.visible') || expression.includes('to.be.attached')) {
+            return (buildOrLocator(candidates) as any)._expect(expression, options);
+          }
+          return (primary as any)._expect(expression, options);
+        };
+      }
+
+      if (typeof prop !== 'string') return (primary as any)[prop];
+
+      if (unsupported.has(prop)) {
+        return () => {
+          throw new Error(`FallbackLocator does not support ${prop}`);
+        };
+      }
+
+      if (LOCATOR_CHAIN_METHODS.has(prop)) {
+        return (...args: any[]) =>
+          createFallbackLocator(
+            candidates.map((candidate) => {
+              const method = (candidate as any)[prop] as LocatorMethod;
+              return method.apply(candidate, args);
+            }),
+          );
+      }
+
+      if (prop === 'count') {
+        return async (...args: any[]) => {
+          const primaryCount = await primary.count(...args);
+          if (primaryCount > 0) return primaryCount;
+          const fallback = await firstPresentFallback(candidates);
+          if (!fallback) return primaryCount;
+          return fallback.count(...args);
+        };
+      }
+
+      const primaryMethod = (primary as any)[prop] as LocatorMethod;
+      if (typeof primaryMethod !== 'function') return primaryMethod;
+
+      if (ACTION_METHODS.has(prop)) {
+        return async (...args: any[]) => {
+          try {
+            return await primaryMethod.apply(primary, args);
+          } catch (error) {
+            const fallback = await firstPresentFallback(candidates);
+            if (!fallback) throw error;
+            const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
+            return fallbackMethod.apply(fallback, withNoWaitTimeout(prop, args));
+          }
+        };
+      }
+
+      return (...args: any[]) => {
+        const result = primaryMethod.apply(primary, args);
+        if (!result || typeof result !== 'object' || typeof (result as Promise<unknown>).catch !== 'function') {
+          return result;
+        }
+
+        return (result as Promise<unknown>).catch(async (error: unknown) => {
+          const fallback = await firstPresentFallback(candidates);
+          if (!fallback) throw error;
+          const fallbackMethod = (fallback as any)[prop] as LocatorMethod;
+          return fallbackMethod.apply(fallback, args);
+        });
+      };
+    },
+  });
+
+  return proxy as Locator;
+}

--- a/packages/playwright/src/fuzzy-locator.ts
+++ b/packages/playwright/src/fuzzy-locator.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from '@playwright/test';
+import { createFallbackLocator } from './fallback-locator';
 
 function debug(...args: unknown[]) {
   if (process.env.LETSRUNIT_DEBUG_FUZZY_LOCATOR === '1') {
@@ -8,10 +9,16 @@ function debug(...args: unknown[]) {
 }
 
 /**
- * Locates an element using Playwright selectors, with lazy fallbacks.
+ * Locates an element using Playwright selectors, with ordered runtime fallbacks.
  */
 export async function fuzzyLocator(page: Page, selector: string): Promise<Locator> {
   debug('input selector:', selector);
+  const candidates = buildFuzzyCandidates(page, selector);
+  debug('enabled fallbacks:', candidates.length > 1 ? String(candidates.length - 1) : '(none)');
+  return createFallbackLocator(candidates);
+}
+
+function buildFuzzyCandidates(page: Page, selector: string): Locator[] {
   const primary = page.locator(selector);
   const candidates: Array<{ name: string; locator: Locator | null }> = [
     { name: 'relaxNameToHasText', locator: tryRelaxNameToHasText(page, selector) },
@@ -21,19 +28,13 @@ export async function fuzzyLocator(page: Page, selector: string): Promise<Locato
     { name: 'asField', locator: tryAsField(page, selector) },
   ];
 
-  let combined = primary;
-  const enabled: string[] = [];
-
+  const all = [primary];
   for (const candidate of candidates) {
     if (!candidate.locator) continue;
-    enabled.push(candidate.name);
-    combined = combined.or(candidate.locator);
+    debug('enabling fallback:', candidate.name, candidate.locator.toString());
+    all.push(candidate.locator);
   }
-  debug('enabled fallbacks:', enabled.length ? enabled.join(', ') : '(none)');
-
-  const result = combined.first();
-  debug('returning locator:', result.toString());
-  return result;
+  return all;
 }
 
 // Preserve the selector but relax [name="..."] to [has-text="..."]

--- a/packages/playwright/src/fuzzy-locator.ts
+++ b/packages/playwright/src/fuzzy-locator.ts
@@ -65,12 +65,12 @@ function tryTagInsteadOfRole(page: Page, selector: string): Locator | null {
 
 // If a role selector with a name filter fails, try proximity-based fallback while
 // preserving the role and any remainder of the selector.
-// Example: role=switch[name="Adres tonen"i] → text=Adres tonen >> .. >> role=switch
+// Example: role=switch[name="Adres tonen"i] → text=Adres tonen >> xpath=following-sibling::* >> role=switch
 function tryRoleNameProximity(page: Page, selector: string): Locator | null {
   const matchRole = selector.match(/^role=(\w+)\s*\[name="([^"]+)"i?](.*)$/i);
   if (!matchRole) return null;
   const [, role, name, rest] = matchRole;
-  const proximitySelector = `text=${name} >> .. >> role=${role}${rest}`;
+  const proximitySelector = `text=${name} >> xpath=following-sibling::* >> role=${role}${rest}`;
   return page.locator(proximitySelector);
 }
 

--- a/packages/playwright/tests/fuzzy-locator.test.ts
+++ b/packages/playwright/tests/fuzzy-locator.test.ts
@@ -235,4 +235,11 @@ describe('fuzzyLocator', () => {
     expect(() => (locator as any).getByRole('button')).toThrow('FallbackLocator does not support getByRole');
     expect(() => (locator as any).getByLabel('name')).toThrow('FallbackLocator does not support getByLabel');
   });
+
+  test('toString returns primary locator with fuzzy marker', async () => {
+    const ctx = createMockContext();
+    const locator = await fuzzyLocator(ctx.page, 'role=button[name="Save"]');
+
+    expect(locator.toString()).toBe('role=button[name="Save"] {fuzzy}');
+  });
 });

--- a/packages/playwright/tests/fuzzy-locator.test.ts
+++ b/packages/playwright/tests/fuzzy-locator.test.ts
@@ -7,11 +7,30 @@ type LocatorCall = {
   options?: Parameters<Page['locator']>[1];
 };
 
+type ClickCall = {
+  id: string;
+  options: unknown;
+};
+
+type ExpectCall = {
+  id: string;
+  expression: string;
+};
+
 type MockedLocator = Locator & {
   __id: string;
-  or: ReturnType<typeof vi.fn>;
-  first: ReturnType<typeof vi.fn>;
+  click: ReturnType<typeof vi.fn>;
   count: ReturnType<typeof vi.fn>;
+  all: ReturnType<typeof vi.fn>;
+  locator: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  _expect: ReturnType<typeof vi.fn>;
+};
+
+type ContextConfig = {
+  counts?: Record<string, number>;
+  clickErrors?: string[];
+  allResults?: Record<string, string[]>;
 };
 
 function locatorId(selector: string, options?: Parameters<Page['locator']>[1]): string {
@@ -19,30 +38,55 @@ function locatorId(selector: string, options?: Parameters<Page['locator']>[1]): 
   return hasText ? `${selector} [hasText=${String(hasText)}]` : selector;
 }
 
-function createMockContext() {
-  const orCalls: Array<[string, string]> = [];
-  const firstCalls: string[] = [];
-  const countCalls: string[] = [];
+function createMockContext(config: ContextConfig = {}) {
   const locatorCalls: LocatorCall[] = [];
+  const clickCalls: ClickCall[] = [];
+  const countCalls: string[] = [];
+  const allCalls: string[] = [];
+  const locatorChainCalls: Array<{ id: string; child: string }> = [];
+  const orCalls: Array<[string, string]> = [];
+  const expectCalls: ExpectCall[] = [];
+  const cache = new Map<string, MockedLocator>();
+  const clickErrors = new Set(config.clickErrors ?? []);
 
   const makeLocator = (id: string): MockedLocator => {
+    const cached = cache.get(id);
+    if (cached) return cached;
+
     const loc = {
       __id: id,
+      click: vi.fn(async (options?: unknown) => {
+        clickCalls.push({ id, options });
+        if (clickErrors.has(id)) {
+          throw new Error(`click failed: ${id}`);
+        }
+      }),
+      count: vi.fn(async () => {
+        countCalls.push(id);
+        return config.counts?.[id] ?? 0;
+      }),
+      all: vi.fn(async () => {
+        allCalls.push(id);
+        const values = config.allResults?.[id] ?? [id];
+        return values.map((value) => makeLocator(value));
+      }),
+      locator: vi.fn((child: string) => {
+        locatorChainCalls.push({ id, child });
+        return makeLocator(`${id} >> ${child}`);
+      }),
       or: vi.fn((other: Locator) => {
         const rhs = other as MockedLocator;
         orCalls.push([id, rhs.__id]);
         return makeLocator(`(${id}) OR (${rhs.__id})`);
       }),
-      first: vi.fn(() => {
-        firstCalls.push(id);
-        return makeLocator(`FIRST(${id})`);
+      _expect: vi.fn(async (expression: string) => {
+        expectCalls.push({ id, expression });
+        return { matches: true, received: id };
       }),
-      count: vi.fn(async () => {
-        countCalls.push(id);
-        return 0;
-      }),
+      toString: vi.fn(() => id),
     } as unknown as MockedLocator;
 
+    cache.set(id, loc);
     return loc;
   };
 
@@ -53,7 +97,16 @@ function createMockContext() {
     }),
   } as unknown as Page;
 
-  return { page, locatorCalls, orCalls, firstCalls, countCalls };
+  return {
+    page,
+    locatorCalls,
+    clickCalls,
+    countCalls,
+    allCalls,
+    locatorChainCalls,
+    orCalls,
+    expectCalls,
+  };
 }
 
 describe('fuzzyLocator', () => {
@@ -61,21 +114,28 @@ describe('fuzzyLocator', () => {
     expect(fuzzyLocator).toBeDefined();
   });
 
-  test('returns primary first locator when selector has no fallback patterns', async () => {
+  test('uses primary action when it succeeds', async () => {
     const ctx = createMockContext();
+    const locator = (await fuzzyLocator(ctx.page, 'my-selector')) as MockedLocator;
 
-    const result = (await fuzzyLocator(ctx.page, 'my-selector')) as MockedLocator;
+    await locator.click({ timeout: 2500 });
 
-    expect(result.__id).toBe('FIRST(my-selector)');
     expect(ctx.locatorCalls).toEqual([{ selector: 'my-selector', options: undefined }]);
-    expect(ctx.orCalls).toEqual([]);
-    expect(ctx.firstCalls).toEqual(['my-selector']);
+    expect(ctx.clickCalls).toEqual([{ id: 'my-selector', options: { timeout: 2500 } }]);
+    expect(ctx.countCalls).toEqual([]);
   });
 
-  test('adds role+name fallbacks lazily in stable order', async () => {
-    const ctx = createMockContext();
+  test('tries primary with timeout, then no-wait fallback existence checks', async () => {
+    const ctx = createMockContext({
+      counts: {
+        'role=button [hasText=Save]': 0,
+        'css=button [hasText=Save]': 1,
+      },
+      clickErrors: ['role=button[name="Save"]'],
+    });
 
-    const result = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
+    const locator = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
+    await locator.click({ timeout: 2500 });
 
     expect(ctx.locatorCalls).toEqual([
       { selector: 'role=button[name="Save"]', options: undefined },
@@ -84,64 +144,95 @@ describe('fuzzyLocator', () => {
       { selector: 'text=Save >> xpath=following-sibling::* >> role=button', options: undefined },
       { selector: 'field=Save', options: undefined },
     ]);
-
-    expect(ctx.orCalls).toEqual([
-      ['role=button[name="Save"]', 'role=button [hasText=Save]'],
-      ['(role=button[name="Save"]) OR (role=button [hasText=Save])', 'css=button [hasText=Save]'],
-      [
-        '((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])',
-        'text=Save >> xpath=following-sibling::* >> role=button',
-      ],
-      [
-        '(((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> xpath=following-sibling::* >> role=button)',
-        'field=Save',
-      ],
+    expect(ctx.clickCalls).toEqual([
+      { id: 'role=button[name="Save"]', options: { timeout: 2500 } },
+      { id: 'css=button [hasText=Save]', options: { timeout: 0 } },
     ]);
+    expect(ctx.countCalls).toEqual(['role=button [hasText=Save]', 'css=button [hasText=Save]']);
+  });
 
-    expect(ctx.firstCalls).toEqual([
-      '((((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> xpath=following-sibling::* >> role=button)) OR (field=Save)',
+  test('rethrows primary error when no fallback exists', async () => {
+    const ctx = createMockContext({
+      clickErrors: ['role=button[name="Save"]'],
+    });
+    const locator = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
+
+    await expect(locator.click({ timeout: 1000 })).rejects.toThrow('click failed: role=button[name="Save"]');
+    expect(ctx.countCalls).toEqual([
+      'role=button [hasText=Save]',
+      'css=button [hasText=Save]',
+      'text=Save >> xpath=following-sibling::* >> role=button',
+      'field=Save',
     ]);
-
-    expect(result.__id).toContain('FIRST(');
   });
 
-  test('maps role=link fallback to css=a', async () => {
+  test('routes toBeVisible and toBeAttached expectations through OR locator', async () => {
     const ctx = createMockContext();
+    const locator = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
 
-    await fuzzyLocator(ctx.page, 'role=link[name="Home"]');
+    await (locator as any)._expect('to.be.visible', { timeout: 5000 });
+    await (locator as any)._expect('to.be.attached', { timeout: 5000 });
 
-    const cssAttempt = ctx.locatorCalls.find((call) => call.selector === 'css=a');
-    expect(cssAttempt).toEqual({ selector: 'css=a', options: { hasText: 'Home' } });
-  });
-
-  test('skips field fallback for non-field roles', async () => {
-    const ctx = createMockContext();
-
-    await fuzzyLocator(ctx.page, 'role=heading[name="Title"]');
-
-    const fieldAttempt = ctx.locatorCalls.find((call) => call.selector.startsWith('field='));
-    expect(fieldAttempt).toBeUndefined();
-  });
-
-  test('adds field alternative only for valid CSS id labels', async () => {
-    const valid = createMockContext();
-    await fuzzyLocator(valid.page, 'field="email"');
-    expect(valid.locatorCalls).toEqual([
-      { selector: 'field="email"', options: undefined },
-      { selector: '#email > input', options: undefined },
-    ]);
-
-    const invalid = createMockContext();
-    await fuzzyLocator(invalid.page, 'field="What needs to be done?"i');
-    expect(invalid.locatorCalls).toEqual([{ selector: 'field="What needs to be done?"i', options: undefined }]);
-  });
-
-  test('does not use eager count checks (race-safe lazy fallback composition)', async () => {
-    const ctx = createMockContext();
-
-    await fuzzyLocator(ctx.page, 'role=button[name="Antenna"]');
-
-    expect(ctx.countCalls).toEqual([]);
     expect(ctx.orCalls.length).toBeGreaterThan(0);
+    expect(ctx.expectCalls.at(-1)?.id).toContain('OR');
+  });
+
+  test('all() aggregates all candidate results', async () => {
+    const ctx = createMockContext({
+      allResults: {
+        'role=button[name="Save"]': ['p1'],
+        'role=button [hasText=Save]': ['f1'],
+        'css=button [hasText=Save]': ['f2'],
+        'text=Save >> xpath=following-sibling::* >> role=button': ['f3'],
+        'field=Save': ['f4'],
+      },
+    });
+    const locator = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
+
+    const result = (await locator.all()) as MockedLocator[];
+
+    expect(ctx.allCalls).toEqual([
+      'role=button[name="Save"]',
+      'role=button [hasText=Save]',
+      'css=button [hasText=Save]',
+      'text=Save >> xpath=following-sibling::* >> role=button',
+      'field=Save',
+    ]);
+    expect(result.map((entry) => entry.__id)).toEqual(['p1', 'f1', 'f2', 'f3', 'f4']);
+  });
+
+  test('applies ordered fallback behavior on chained locator', async () => {
+    const ctx = createMockContext({
+      counts: {
+        'role=button [hasText=Save] >> svg': 0,
+        'css=button [hasText=Save] >> svg': 1,
+      },
+      clickErrors: ['role=button[name="Save"] >> svg'],
+    });
+    const locator = (await fuzzyLocator(ctx.page, 'role=button[name="Save"]')) as MockedLocator;
+
+    const child = locator.locator('svg') as MockedLocator;
+    await child.click({ timeout: 2500 });
+
+    expect(ctx.locatorChainCalls).toEqual([
+      { id: 'role=button[name="Save"]', child: 'svg' },
+      { id: 'role=button [hasText=Save]', child: 'svg' },
+      { id: 'css=button [hasText=Save]', child: 'svg' },
+      { id: 'text=Save >> xpath=following-sibling::* >> role=button', child: 'svg' },
+      { id: 'field=Save', child: 'svg' },
+    ]);
+    expect(ctx.clickCalls).toEqual([
+      { id: 'role=button[name="Save"] >> svg', options: { timeout: 2500 } },
+      { id: 'css=button [hasText=Save] >> svg', options: { timeout: 0 } },
+    ]);
+  });
+
+  test('throws for unsupported methods', async () => {
+    const ctx = createMockContext();
+    const locator = await fuzzyLocator(ctx.page, 'my-selector');
+
+    expect(() => (locator as any).filter({ hasText: 'x' })).toThrow('FallbackLocator does not support filter');
+    expect(() => (locator as any).getByRole('button')).toThrow('FallbackLocator does not support getByRole');
+    expect(() => (locator as any).getByLabel('name')).toThrow('FallbackLocator does not support getByLabel');
   });
 });

--- a/packages/playwright/tests/fuzzy-locator.test.ts
+++ b/packages/playwright/tests/fuzzy-locator.test.ts
@@ -81,7 +81,7 @@ describe('fuzzyLocator', () => {
       { selector: 'role=button[name="Save"]', options: undefined },
       { selector: 'role=button', options: { hasText: 'Save' } },
       { selector: 'css=button', options: { hasText: 'Save' } },
-      { selector: 'text=Save >> .. >> role=button', options: undefined },
+      { selector: 'text=Save >> xpath=following-sibling::* >> role=button', options: undefined },
       { selector: 'field=Save', options: undefined },
     ]);
 
@@ -90,16 +90,16 @@ describe('fuzzyLocator', () => {
       ['(role=button[name="Save"]) OR (role=button [hasText=Save])', 'css=button [hasText=Save]'],
       [
         '((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])',
-        'text=Save >> .. >> role=button',
+        'text=Save >> xpath=following-sibling::* >> role=button',
       ],
       [
-        '(((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> .. >> role=button)',
+        '(((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> xpath=following-sibling::* >> role=button)',
         'field=Save',
       ],
     ]);
 
     expect(ctx.firstCalls).toEqual([
-      '((((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> .. >> role=button)) OR (field=Save)',
+      '((((role=button[name="Save"]) OR (role=button [hasText=Save])) OR (css=button [hasText=Save])) OR (text=Save >> xpath=following-sibling::* >> role=button)) OR (field=Save)',
     ]);
 
     expect(result.__id).toContain('FIRST(');


### PR DESCRIPTION
## Type

Bug fix / Refactor

## Summary

Fix fuzzy locator fallback behavior to resolve at action time with primary-first semantics, and make reporter fuzzy detection explicit via a `{fuzzy}` marker instead of parsing fallback chains.

## Changes

- Add `FallbackLocator` runtime wrapper and move fallback dispatch logic into `packages/playwright/src/fallback-locator.ts`
- Change fuzzy locator resolution to primary-first execution, then no-wait fallback existence checks
- Keep `toBeVisible`/`toBeAttached` expectation behavior via OR resolution; keep unsupported methods explicit
- Update `FallbackLocator.toString()` to emit primary locator with `{fuzzy}` marker
- Update cucumber reporter parsing (`progress` and `agent`) to rely on `{fuzzy}` marker for fuzzy status
- Remove reporter backward-compat assumptions for `.or(...)` and `FallbackLocator(...)` parsing
- Add/update focused tests for playwright fuzzy locator and cucumber reporter parsing

## Breaking changes

Reporter fuzzy tagging now relies on `{fuzzy}` marker in locator strings; legacy fuzzy detection from `.or(...)` / `FallbackLocator(...)` text is no longer used.