### PR TITLE
docs: simplify docs landing and fix pages deploy artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,16 +38,9 @@ jobs:
       - name: Build
         run: yarn workspace letsrunit-docs build
 
-      - name: Package Pages artifact (include dotfiles)
-        run: |
-          set -euo pipefail
-          tar --format=posix -cvf /tmp/github-pages.tar -C docusaurus/build .
-          gzip -f /tmp/github-pages.tar
-
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-pages-artifact@v4
         with:
-          name: github-pages
-          path: /tmp/github-pages.tar.gz
+          path: docusaurus/build
           include-hidden-files: true
 
   deploy:

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -80,7 +80,12 @@ const config: Config = {
       additionalLanguages: ['gherkin'],
     },
     navbar: {
-      title: 'Letsrunit',
+      title: '',
+      logo: {
+        alt: 'Letsrunit',
+        src: 'img/logo-light.svg',
+        srcDark: 'img/logo.svg',
+      },
       items: [
         {
           href: 'https://github.com/letsrunit-hq/letsrunit',
@@ -91,7 +96,7 @@ const config: Config = {
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} letsrunit-hq`,
+      copyright: `Copyright © ${new Date().getFullYear()} Jasny`,
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Type

Docs / Chore

## Summary

Align docs with the product positioning by making the landing page action-first and collapsing AI docs, while fixing GitHub Pages deployment so `.gitbook` assets are included without breaking `deploy-pages`.

## Changes

- Simplified docs landing page to lead with `npx letsrunit init` and removed long persuasive sections
- Removed Installation from docs navigation and collapsed AI docs navigation to a single page
- Updated Docusaurus navbar to use logo (light/dark variants) and set footer owner to `Jasny`
- Standardized docs prose branding to `Letsrunit` where applicable
- Fixed docs deploy workflow to use `actions/upload-pages-artifact@v4` with `include-hidden-files: true`
- Upgraded `actions/upload-artifact` to `v7` in init workflow

## Breaking changes

None.
