### PR TITLE
fix(playwright): preserve locator identity for fallback proxy

### DIFF
--- a/.github/scripts/mcp/mcp-int.package.json
+++ b/.github/scripts/mcp/mcp-int.package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mcp-int",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@letsrunit/mcp-server": "file:/tmp/mcp-server.tgz",
+    "@modelcontextprotocol/sdk": "^1.26.0"
+  },
+  "overrides": {
+    "@letsrunit/ai": "file:/tmp/ai.tgz",
+    "@letsrunit/bdd": "file:/tmp/bdd.tgz",
+    "@letsrunit/cli": "file:/tmp/cli.tgz",
+    "@letsrunit/controller": "file:/tmp/controller.tgz",
+    "@letsrunit/cucumber": "file:/tmp/cucumber.tgz",
+    "@letsrunit/executor": "file:/tmp/executor.tgz",
+    "@letsrunit/gherker": "file:/tmp/gherker.tgz",
+    "@letsrunit/gherkin": "file:/tmp/gherkin.tgz",
+    "@letsrunit/journal": "file:/tmp/journal.tgz",
+    "@letsrunit/mailbox": "file:/tmp/mailbox.tgz",
+    "@letsrunit/mcp-server": "file:/tmp/mcp-server.tgz",
+    "@letsrunit/playwright": "file:/tmp/playwright.tgz",
+    "@letsrunit/store": "file:/tmp/store.tgz",
+    "@letsrunit/utils": "file:/tmp/utils.tgz",
+    "letsrunit": "file:/tmp/letsrunit.tgz"
+  }
+}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -180,17 +180,7 @@ jobs:
           curl --retry 10 --retry-delay 1 --retry-connrefused -sf http://127.0.0.1:3000/
 
           mkdir -p /tmp/mcp-int
-          cat >/tmp/mcp-int/package.json <<'EOF'
-          {
-            "name": "mcp-int",
-            "private": true,
-            "type": "module",
-            "dependencies": {
-              "@letsrunit/mcp-server": "file:/tmp/mcp-server.tgz",
-              "@modelcontextprotocol/sdk": "^1.26.0"
-            }
-          }
-          EOF
+          cp .github/scripts/mcp/mcp-int.package.json /tmp/mcp-int/package.json
           (cd /tmp/mcp-int && npm install --no-audit --no-fund)
           (cd /tmp/mcp-int && npx playwright install chromium)
           cp .github/scripts/mcp/run-deterministic-flow.mjs /tmp/mcp-int/run-deterministic-flow.mjs

--- a/packages/playwright/src/fallback-locator.ts
+++ b/packages/playwright/src/fallback-locator.ts
@@ -154,10 +154,12 @@ function formatLocatorChain(candidates: Locator[]): string {
 export function createFallbackLocator(candidates: Locator[]): Locator {
   const primary = candidates[0];
   const unsupported = new Set(['filter', 'getByRole', 'getByLabel']);
+  const passthroughMetaProperties = new Set(['constructor', '__proto__']);
 
   const proxy = new Proxy(primary as unknown as object, {
     get(_target, prop: ProxyProperty) {
       if (typeof prop !== 'string') return (primary as any)[prop];
+      if (passthroughMetaProperties.has(prop)) return (primary as any)[prop];
 
       switch (prop) {
         case 'toString':

--- a/packages/playwright/tests/fuzzy-locator.test.ts
+++ b/packages/playwright/tests/fuzzy-locator.test.ts
@@ -1,5 +1,6 @@
-import { Locator, Page } from '@playwright/test';
+import { expect as pwExpect, Locator, Page } from '@playwright/test';
 import { describe, expect, test, vi } from 'vitest';
+import { createFallbackLocator } from '../src/fallback-locator';
 import { fuzzyLocator } from '../src';
 
 type LocatorCall = {
@@ -31,6 +32,14 @@ type ContextConfig = {
   counts?: Record<string, number>;
   clickErrors?: string[];
   allResults?: Record<string, string[]>;
+};
+
+type ExpectResponse = {
+  matches: boolean;
+  received?: string;
+  timedOut?: boolean;
+  errorMessage?: string;
+  log?: string[];
 };
 
 function locatorId(selector: string, options?: Parameters<Page['locator']>[1]): string {
@@ -106,6 +115,22 @@ function createMockContext(config: ContextConfig = {}) {
     locatorChainCalls,
     orCalls,
     expectCalls,
+  };
+}
+
+function createPlaywrightLocatorStub(response: ExpectResponse): Locator & {
+  _expect: ReturnType<typeof vi.fn>;
+  toString: ReturnType<typeof vi.fn>;
+} {
+  const LocatorCtor = new Function('return function Locator() {}')() as { prototype: object };
+  const locator = Object.create(LocatorCtor.prototype);
+  const expectMock = vi.fn(async () => response);
+  const toStringMock = vi.fn(() => 'stub=locator');
+  locator._expect = expectMock;
+  locator.toString = toStringMock;
+  return locator as Locator & {
+    _expect: ReturnType<typeof vi.fn>;
+    toString: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -241,5 +266,26 @@ describe('fuzzyLocator', () => {
     const locator = await fuzzyLocator(ctx.page, 'role=button[name="Save"]');
 
     expect(locator.toString()).toBe('role=button[name="Save"] {fuzzy}');
+  });
+
+  test('remains compatible with Playwright locator matcher type checks', async () => {
+    const primary = createPlaywrightLocatorStub({ matches: true, received: 'visible' });
+    const locator = createFallbackLocator([primary]);
+    expect((locator as any).constructor.name).toBe('Locator');
+
+    await expect(pwExpect(locator).toBeVisible()).resolves.toBeUndefined();
+    expect(primary._expect).toHaveBeenCalledWith(
+      'to.be.visible',
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  test('fails with matcher output, not locator-type guard errors', async () => {
+    const primary = createPlaywrightLocatorStub({ matches: false, received: 'hidden' });
+    const locator = createFallbackLocator([primary]);
+
+    await expect(pwExpect(locator).toBeVisible({ timeout: 1 })).rejects.not.toThrow(
+      'toBeVisible can be only used with Locator object',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- preserve locator meta identity on fallback proxy by passing through `constructor`/`__proto__`
- add contract tests to ensure Playwright matcher type checks accept fallback locators
- add regression assertion that matcher failures are not locator-type guard failures

## Validation
- `yarn test --project @letsrunit/playwright tests/fuzzy-locator.test.ts`
- `yarn test --project @letsrunit/playwright`
- local CI-equivalent MCP deterministic flow using packed tarballs for `@letsrunit/mcp-server` and `@letsrunit/playwright`