### PR TITLE
feat(letsrunit): detect app ports before scaffolding init assets

### DIFF
--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -21,6 +21,14 @@ npx letsrunit init
 
 The init script will automatically detect all the components to install and configure.
 
+You can also force specific agents:
+
+```bash
+npx letsrunit init --agents codex,cursor
+```
+
+If multiple agents are detected, `init` asks which ones to configure. In non-interactive mode (or with `--yes`), pass `--agents` explicitly to enable agent setup.
+
 ### Global
 
 You can install the Letsrunit MCP server and skill globally for all your projects.
@@ -137,4 +145,3 @@ If you cannot write a scenario before implementing, the requirements are not spe
 ```
 {% endtab %}
 {% endtabs %}
-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,16 @@ npx letsrunit init
 
 `init` is interactive: it walks you through each step and asks before making changes. It's safe to re-run at any time.
 
+For AI agent setup, you can choose explicit agents:
+
+```bash
+npx letsrunit init --agents codex,cursor
+```
+
+Supported values: `codex`, `cursor`, `claude`, `copilot`, `gemini`, `windsurf`.
+
+If `--yes` is used without `--agents`, agent configuration is skipped.
+
 ### What does the installer do?
 
 {% stepper %}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,8 +53,9 @@ program
   .description('Set up letsrunit in the current project')
   .option('-y, --yes', 'Skip confirmation prompts')
   .option('--no-mcp', 'Do not install @letsrunit/mcp-server')
-  .action(async (opts: { yes?: boolean; mcp?: boolean }) => {
-    await init({ yes: opts.yes, noMcp: opts.mcp === false });
+  .option('--agents <list>', 'Configure MCP + skill for agents (comma-separated)')
+  .action(async (opts: { yes?: boolean; mcp?: boolean; agents?: string }) => {
+    await init({ yes: opts.yes, noMcp: opts.mcp === false, agents: opts.agents });
   });
 
 program

--- a/packages/letsrunit/README.md
+++ b/packages/letsrunit/README.md
@@ -32,6 +32,10 @@ It can:
 - `--no-mcp`  
   Skip installation of `@letsrunit/mcp-server`.
 
+- `--agents <list>`  
+  Configure MCP + skill for selected agents (comma-separated): `codex,cursor,claude,copilot,gemini,windsurf`.
+  If omitted in non-interactive mode or with `--yes`, agent config is skipped.
+
 ## Generated/updated files
 
 When scaffolding Cucumber support, `init` creates:

--- a/packages/letsrunit/src/bin.ts
+++ b/packages/letsrunit/src/bin.ts
@@ -1,17 +1,20 @@
 import { init } from './init.js';
+import { parseAgents } from './setup/agents.js';
 
 const args = process.argv.slice(2);
 const command = args.find((a) => !a.startsWith('-')) ?? 'init';
 const yes = args.includes('--yes') || args.includes('-y');
 const noMcp = args.includes('--no-mcp');
+const agentsIndex = args.indexOf('--agents');
+const agentsArg = agentsIndex >= 0 ? args[agentsIndex + 1] : undefined;
 
 if (command === 'init') {
-  init({ yes, noMcp }).catch((err: unknown) => {
+  init({ yes, noMcp, agents: parseAgents(agentsArg) }).catch((err: unknown) => {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   });
 } else {
   console.error(`Unknown command: ${command}`);
-  console.error('Usage: letsrunit init [--yes] [--no-mcp]');
+  console.error('Usage: letsrunit init [--yes] [--no-mcp] [--agents codex,cursor]');
   process.exit(1);
 }

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -2,6 +2,7 @@ import { confirm, intro, log, note, outro, spinner } from '@clack/prompts';
 import { detectEnvironment, type Environment } from './detect.js';
 import { installCli, isCliInstalled } from './setup/cli.js';
 import { installCucumber, setupCucumber } from './setup/cucumber.js';
+import { parseAgents, setupAgents } from './setup/agents.js';
 import { installGithubAction } from './setup/github-actions.js';
 import { installMcpServer, isMcpServerInstalled } from './setup/mcp.js';
 import { hasPlaywrightBrowsers, installPlaywrightBrowsers } from './setup/playwright.js';
@@ -11,6 +12,7 @@ const BDD_IMPORT = '@letsrunit/cucumber';
 export interface InitOptions {
   yes?: boolean;
   noMcp?: boolean;
+  agents?: string | string[];
 }
 
 async function stepInstallCli(env: Environment): Promise<void> {
@@ -129,9 +131,12 @@ export async function init(options: InitOptions = {}): Promise<void> {
   intro('letsrunit init');
 
   const env = detectEnvironment();
+  const agentValue = Array.isArray(options.agents) ? options.agents.join(',') : options.agents;
+  const agentIds = parseAgents(agentValue);
 
   await stepInstallCli(env);
   await stepInstallMcpServer(env, options);
+  await setupAgents(env, { ...options, agents: agentIds });
 
   const hasCucumber = await stepEnsureCucumber(env, options);
   if (hasCucumber) {

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -11,12 +11,19 @@ import { hasPlaywrightBrowsers, installPlaywrightBrowsers } from './setup/playwr
 const BDD_IMPORT = '@letsrunit/cucumber';
 
 const BANNER = String.raw`
- _      _       _                           _ _
-| | ___| |_ ___| |_ _ __ _   _ _ __ (_) |_
-| |/ _ \ __/ __| __| '__| | | | '_ \| | __|
-| |  __/ |_\__ \ |_| |  | |_| | | | | | |_
-|_|\___|\__|___/\__|_|   \__,_|_| |_|_|\__|
-`;
+        .:::::.                                                                                                         
+     .:::::::::::.          ...                                                                      .-:                
+   .::::::   ::::::         =+=                 .                                                    -+=.    .          
+  .:::           :::        =+=                -+                                                           -+          
+  ::::           ::::       =+=    .-=+==:   -=++===   :==+==:    ==  -==  ==:    .==   -=  :=+=-    :==  -=++===       
+ .:::.   .:::.   .:::.      =+=   =+=:..=+=  :-++-::  =+-...-++   ++.==-=  ++:    :++   =+.--.:=++   -++  :=++-::       
+ .::     :::::     ::.      =+=  -++     =+:  .++     ++-    .    ++-:     ++:    :++   =+=.   .++:  -++   :++          
+ .:::.   .:::    .:::.      =+=  =++=====++-  .++     .=+++=-:    ++=      ++:    :++   =+=     ++-  -++   :++          
+  ::::           ::::       =+=  =+=          .++         .:-++:  ++-      ++-    =++   =+=     ++-  -++   :++          
+  .:::           :::        =+=  .++:    -=:  .++:    -=     =+-  ++-      =+=   ::++   =+=     ++-  -++   :++.     .   
+    ::::::   ::::::         =+=   .=+=-=++-    =++++  :++====+=   ++-      .+++=+- ++   =+=     ++-  -++    =++++  :::  
+     .:::::::::::.           .       .::.       ..:.    ..::.     ..         .:.   ..    .      ..    ..     .::.       
+        .::::..                                                                                                         `;
 
 export interface InitOptions {
   yes?: boolean;
@@ -109,10 +116,10 @@ function stepAddGithubAction(env: Environment): void {
 }
 
 function defaultPlan(env: Environment, options: InitOptions, explicitAgents: AgentId[]): InstallPlan {
-  const installMcp = options.noMcp ? false : !isMcpServerInstalled(env);
-  const installCucumber = !env.hasCucumber;
-  const installPlaywright = !hasPlaywrightBrowsers(env);
-  const addGithubActions = false;
+  const installMcp = !options.noMcp;
+  const installCucumber = true;
+  const installPlaywright = true;
+  const addGithubActions = true;
   const agents = explicitAgents.length > 0 ? explicitAgents : detectAgentIds(env);
   return { installMcp, installCucumber, installPlaywright, addGithubActions, agents };
 }
@@ -132,6 +139,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
     return options.yes ? defaults : { ...defaults, installCucumber: false, installPlaywright: false, addGithubActions: false, agents: [] };
   }
 
+  note('Use ↑/↓ to move, space to toggle, enter to continue.', 'Controls');
   note('`@letsrunit/cli` is always installed and selected.', 'Core Component');
 
   const componentOptions = [
@@ -154,6 +162,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
   const components = await multiselect({
     message: 'Choose what to install/configure for this project',
     options: componentOptions,
+    initialValues: componentOptions.filter((option) => option.selected).map((option) => option.value),
     required: false,
   });
 
@@ -167,6 +176,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
   let selectedAgents: AgentId[] = [];
   if (installMcp) {
     const catalog = getAgentCatalog();
+    note('Use ↑/↓ to move, space to toggle, enter to continue.', 'Agent Controls');
     const picked = await multiselect({
       message: 'AI Agent integration (MCP config + skill)',
       options: catalog.map((agent) => ({
@@ -175,6 +185,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
         selected: defaults.agents.includes(agent.id),
         hint: defaults.agents.includes(agent.id) ? 'detected' : undefined,
       })),
+      initialValues: defaults.agents,
       required: false,
     });
 

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -5,6 +5,8 @@ import { installCli, isCliInstalled } from './setup/cli.js';
 import { installCucumber, setupCucumber } from './setup/cucumber.js';
 import { detectAgentIds, getAgentCatalog, parseAgents, setupAgents } from './setup/agents.js';
 import { installGithubAction } from './setup/github-actions.js';
+import { recommendedBaseUrl, updateCucumberBaseUrl } from './setup/ci-workflow-plan.js';
+import { detectAppTarget, type DetectionResult, type AppTarget } from './setup/project-app.js';
 import { installMcpServer, isMcpServerInstalled } from './setup/mcp.js';
 import { hasPlaywrightBrowsers, installPlaywrightBrowsers } from './setup/playwright.js';
 
@@ -79,8 +81,8 @@ function stepInstallCucumber(env: Environment): void {
   s.stop('@cucumber/cucumber installed');
 }
 
-function stepSetupCucumber(env: Environment): void {
-  const result = setupCucumber(env);
+function stepSetupCucumber(env: Environment, appTarget: DetectionResult<AppTarget>): void {
+  const result = setupCucumber(env, { baseUrl: appTarget.value.baseUrl });
 
   if (result.bddInstalled) log.success('@letsrunit/cucumber installed');
 
@@ -106,12 +108,20 @@ function stepInstallPlaywright(env: Environment): void {
   s.stop('Playwright Chromium installed');
 }
 
-function stepAddGithubAction(env: Environment): void {
-  const result = installGithubAction(env);
-  if (result === 'created') {
+function stepAddGithubAction(env: Environment, appTarget: DetectionResult<AppTarget>): void {
+  const result = installGithubAction(env, { appTarget });
+  if (result.status === 'created') {
     log.success('.github/workflows/letsrunit.yml created');
   } else {
     log.info('.github/workflows/letsrunit.yml already exists, skipped');
+  }
+
+  const baseUrl = recommendedBaseUrl(result.plan);
+  if (baseUrl !== 'http://localhost:3000') {
+    const update = updateCucumberBaseUrl(env.cwd, baseUrl);
+    if (update === 'updated') {
+      log.success(`cucumber.js baseURL updated to ${baseUrl}`);
+    }
   }
 }
 
@@ -212,6 +222,7 @@ export async function init(options: InitOptions = {}): Promise<void> {
   showBanner();
 
   const env = detectEnvironment();
+  const appTarget = detectAppTarget(env.cwd);
   const agentValue = Array.isArray(options.agents) ? options.agents.join(',') : options.agents;
   const explicitAgents = parseAgents(agentValue);
   const plan = await selectPlan(env, options, defaultPlan(env, options, explicitAgents));
@@ -225,11 +236,11 @@ export async function init(options: InitOptions = {}): Promise<void> {
 
   if (plan.installCucumber) stepInstallCucumber(env);
   if (env.hasCucumber || plan.installCucumber) {
-    stepSetupCucumber(env);
+    stepSetupCucumber(env, appTarget);
   }
 
   if (plan.installPlaywright) stepInstallPlaywright(env);
-  if (plan.addGithubActions) stepAddGithubAction(env);
+  if (plan.addGithubActions) stepAddGithubAction(env, appTarget);
 
   outro('All done! Run npx letsrunit --help to get started.');
 }

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -1,18 +1,39 @@
-import { confirm, intro, log, note, outro, spinner } from '@clack/prompts';
+import { intro, isCancel, log, multiselect, note, outro, spinner } from '@clack/prompts';
+import type { AgentId } from './setup/agents/types.js';
 import { detectEnvironment, type Environment } from './detect.js';
 import { installCli, isCliInstalled } from './setup/cli.js';
 import { installCucumber, setupCucumber } from './setup/cucumber.js';
-import { parseAgents, setupAgents } from './setup/agents.js';
+import { detectAgentIds, getAgentCatalog, parseAgents, setupAgents } from './setup/agents.js';
 import { installGithubAction } from './setup/github-actions.js';
 import { installMcpServer, isMcpServerInstalled } from './setup/mcp.js';
 import { hasPlaywrightBrowsers, installPlaywrightBrowsers } from './setup/playwright.js';
 
 const BDD_IMPORT = '@letsrunit/cucumber';
 
+const BANNER = String.raw`
+ _      _       _                           _ _
+| | ___| |_ ___| |_ _ __ _   _ _ __ (_) |_
+| |/ _ \ __/ __| __| '__| | | | '_ \| | __|
+| |  __/ |_\__ \ |_| |  | |_| | | | | | |_
+|_|\___|\__|___/\__|_|   \__,_|_| |_|_|\__|
+`;
+
 export interface InitOptions {
   yes?: boolean;
   noMcp?: boolean;
   agents?: string | string[];
+}
+
+interface InstallPlan {
+  installMcp: boolean;
+  installCucumber: boolean;
+  installPlaywright: boolean;
+  addGithubActions: boolean;
+  agents: AgentId[];
+}
+
+function showBanner(): void {
+  console.log(BANNER);
 }
 
 async function stepInstallCli(env: Environment): Promise<void> {
@@ -27,53 +48,28 @@ async function stepInstallCli(env: Environment): Promise<void> {
   s.stop('@letsrunit/cli installed');
 }
 
-async function stepEnsureCucumber(env: Environment, { yes }: InitOptions): Promise<boolean> {
-  if (env.hasCucumber) return true;
-
-  if (!yes && !env.isInteractive) {
-    log.warn('@cucumber/cucumber not found. Install it to use letsrunit with Cucumber:');
-    note('npm install --save-dev @cucumber/cucumber\nThen run: npx letsrunit init', 'Setup Cucumber');
-    return false;
-  }
-
-  if (!yes) {
-    const install = await confirm({ message: '@cucumber/cucumber not found. Install it now?' });
-    if (install !== true) return false;
-  }
-
-  const s = spinner();
-  s.start('Installing @cucumber/cucumber…');
-  installCucumber(env);
-  s.stop('@cucumber/cucumber installed');
-  return true;
-}
-
-async function stepInstallMcpServer(env: Environment, { yes, noMcp }: InitOptions): Promise<void> {
-  if (noMcp) {
-    log.info('Skipped @letsrunit/mcp-server installation (--no-mcp).');
-    return;
-  }
-
+function stepInstallMcpServer(env: Environment): void {
   if (isMcpServerInstalled(env)) {
     log.success('@letsrunit/mcp-server already installed');
     return;
-  }
-
-  if (!yes && env.isInteractive) {
-    const install = await confirm({
-      message: 'Install @letsrunit/mcp-server for project-local MCP support?',
-      initialValue: true,
-    });
-    if (install !== true) {
-      log.info('Skipped @letsrunit/mcp-server installation.');
-      return;
-    }
   }
 
   const s = spinner();
   s.start('Installing @letsrunit/mcp-server…');
   installMcpServer(env);
   s.stop('@letsrunit/mcp-server installed');
+}
+
+function stepInstallCucumber(env: Environment): void {
+  if (env.hasCucumber) {
+    log.success('@cucumber/cucumber already installed');
+    return;
+  }
+
+  const s = spinner();
+  s.start('Installing @cucumber/cucumber…');
+  installCucumber(env);
+  s.stop('@cucumber/cucumber installed');
 }
 
 function stepSetupCucumber(env: Environment): void {
@@ -91,18 +87,10 @@ function stepSetupCucumber(env: Environment): void {
   if (result.featuresCreated) log.success('features/ directory created with example.feature');
 }
 
-async function stepCheckPlaywrightBrowsers(env: Environment, { yes }: InitOptions): Promise<void> {
-  if (hasPlaywrightBrowsers(env)) return;
-
-  if (!yes && !env.isInteractive) {
-    log.warn('Playwright Chromium browser not found.');
-    note('npx playwright install chromium', 'Run to install browsers');
+function stepInstallPlaywright(env: Environment): void {
+  if (hasPlaywrightBrowsers(env)) {
+    log.success('Playwright Chromium already installed');
     return;
-  }
-
-  if (!yes) {
-    const install = await confirm({ message: 'Playwright Chromium browser not found. Install it now?' });
-    if (install !== true) return;
   }
 
   const s = spinner();
@@ -111,14 +99,7 @@ async function stepCheckPlaywrightBrowsers(env: Environment, { yes }: InitOption
   s.stop('Playwright Chromium installed');
 }
 
-async function stepAddGithubAction(env: Environment, { yes }: InitOptions): Promise<void> {
-  if (!yes && !env.isInteractive) return;
-
-  if (!yes) {
-    const addAction = await confirm({ message: 'Add a GitHub Action to run features on push?' });
-    if (addAction !== true) return;
-  }
-
+function stepAddGithubAction(env: Environment): void {
   const result = installGithubAction(env);
   if (result === 'created') {
     log.success('.github/workflows/letsrunit.yml created');
@@ -127,23 +108,117 @@ async function stepAddGithubAction(env: Environment, { yes }: InitOptions): Prom
   }
 }
 
+function defaultPlan(env: Environment, options: InitOptions, explicitAgents: AgentId[]): InstallPlan {
+  const installMcp = options.noMcp ? false : !isMcpServerInstalled(env);
+  const installCucumber = !env.hasCucumber;
+  const installPlaywright = !hasPlaywrightBrowsers(env);
+  const addGithubActions = false;
+  const agents = explicitAgents.length > 0 ? explicitAgents : detectAgentIds(env);
+  return { installMcp, installCucumber, installPlaywright, addGithubActions, agents };
+}
+
+async function selectPlan(env: Environment, options: InitOptions, defaults: InstallPlan): Promise<InstallPlan> {
+  if (options.yes || !env.isInteractive) {
+    if (!options.yes && !env.isInteractive && defaults.installCucumber) {
+      log.warn('@cucumber/cucumber not found. Install it to use letsrunit with Cucumber:');
+      note('npm install --save-dev @cucumber/cucumber\nThen run: npx letsrunit init', 'Setup Cucumber');
+    }
+
+    if (!options.yes && !env.isInteractive && defaults.installPlaywright) {
+      log.warn('Playwright Chromium browser not found.');
+      note('npx playwright install chromium', 'Run to install browsers');
+    }
+
+    return options.yes ? defaults : { ...defaults, installCucumber: false, installPlaywright: false, addGithubActions: false, agents: [] };
+  }
+
+  note('`@letsrunit/cli` is always installed and selected.', 'Core Component');
+
+  const componentOptions = [
+    { value: 'cucumber', label: 'Cucumber', hint: 'test runner integration', selected: defaults.installCucumber },
+    { value: 'playwright', label: 'Playwright Chromium', hint: 'browser runtime', selected: defaults.installPlaywright },
+    { value: 'gha', label: 'GitHub Actions workflow', hint: 'CI scaffold', selected: defaults.addGithubActions },
+  ];
+
+  if (!options.noMcp) {
+    componentOptions.unshift({
+      value: 'mcp',
+      label: 'MCP Server',
+      hint: 'project-local runtime',
+      selected: defaults.installMcp,
+    });
+  } else {
+    log.info('MCP Server disabled by --no-mcp.');
+  }
+
+  const components = await multiselect({
+    message: 'Choose what to install/configure for this project',
+    options: componentOptions,
+    required: false,
+  });
+
+  if (isCancel(components)) {
+    throw new Error('Initialization canceled.');
+  }
+
+  const values = new Set((components ?? []) as string[]);
+  const installMcp = options.noMcp ? false : values.has('mcp');
+
+  let selectedAgents: AgentId[] = [];
+  if (installMcp) {
+    const catalog = getAgentCatalog();
+    const picked = await multiselect({
+      message: 'AI Agent integration (MCP config + skill)',
+      options: catalog.map((agent) => ({
+        value: agent.id,
+        label: agent.label,
+        selected: defaults.agents.includes(agent.id),
+        hint: defaults.agents.includes(agent.id) ? 'detected' : undefined,
+      })),
+      required: false,
+    });
+
+    if (isCancel(picked)) {
+      throw new Error('Initialization canceled.');
+    }
+
+    selectedAgents = (picked ?? []) as AgentId[];
+  } else {
+    log.info('MCP Server not selected. AI agent integration options skipped.');
+  }
+
+  return {
+    installMcp,
+    installCucumber: values.has('cucumber'),
+    installPlaywright: values.has('playwright'),
+    addGithubActions: values.has('gha'),
+    agents: selectedAgents,
+  };
+}
+
 export async function init(options: InitOptions = {}): Promise<void> {
   intro('letsrunit init');
+  showBanner();
 
   const env = detectEnvironment();
   const agentValue = Array.isArray(options.agents) ? options.agents.join(',') : options.agents;
-  const agentIds = parseAgents(agentValue);
+  const explicitAgents = parseAgents(agentValue);
+  const plan = await selectPlan(env, options, defaultPlan(env, options, explicitAgents));
 
   await stepInstallCli(env);
-  await stepInstallMcpServer(env, options);
-  await setupAgents(env, { ...options, agents: agentIds });
 
-  const hasCucumber = await stepEnsureCucumber(env, options);
-  if (hasCucumber) {
+  if (plan.installMcp) stepInstallMcpServer(env);
+  else if (options.noMcp) log.info('Skipped @letsrunit/mcp-server installation (--no-mcp).');
+
+  await setupAgents(env, { agents: plan.agents, noMcp: Boolean(options.noMcp) });
+
+  if (plan.installCucumber) stepInstallCucumber(env);
+  if (env.hasCucumber || plan.installCucumber) {
     stepSetupCucumber(env);
-    await stepCheckPlaywrightBrowsers(env, options);
-    await stepAddGithubAction(env, options);
   }
+
+  if (plan.installPlaywright) stepInstallPlaywright(env);
+  if (plan.addGithubActions) stepAddGithubAction(env);
 
   outro('All done! Run npx letsrunit --help to get started.');
 }

--- a/packages/letsrunit/src/setup/agents.ts
+++ b/packages/letsrunit/src/setup/agents.ts
@@ -1,0 +1,96 @@
+import { confirm, log, multiselect } from '@clack/prompts';
+import type { Environment } from '../detect.js';
+import { claudeStrategy } from './agents/claude.js';
+import { codexStrategy } from './agents/codex.js';
+import { copilotStrategy } from './agents/copilot.js';
+import { cursorStrategy } from './agents/cursor.js';
+import { geminiStrategy } from './agents/gemini.js';
+import type { AgentId, AgentStrategy } from './agents/types.js';
+import { AGENT_IDS } from './agents/types.js';
+import { windsurfStrategy } from './agents/windsurf.js';
+
+const STRATEGIES: AgentStrategy[] = [codexStrategy, cursorStrategy, claudeStrategy, copilotStrategy, geminiStrategy, windsurfStrategy];
+
+function isAgentId(value: string): value is AgentId {
+  return (AGENT_IDS as readonly string[]).includes(value);
+}
+
+export function parseAgents(value: string | undefined): AgentId[] {
+  if (!value) return [];
+  const ids = value
+    .split(',')
+    .map((agent) => agent.trim().toLowerCase())
+    .filter(Boolean);
+
+  const invalid = ids.filter((id) => !isAgentId(id));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown agent(s): ${invalid.join(', ')}. Valid values: ${AGENT_IDS.join(', ')}`);
+  }
+
+  return [...new Set(ids)] as AgentId[];
+}
+
+function detectAgents(env: Pick<Environment, 'cwd'>): AgentStrategy[] {
+  return STRATEGIES.filter((strategy) => strategy.detect(env));
+}
+
+async function resolveAgentStrategies(
+  env: Pick<Environment, 'cwd' | 'isInteractive'>,
+  options: { agents?: AgentId[]; yes?: boolean },
+): Promise<AgentStrategy[]> {
+  if (options.agents && options.agents.length > 0) {
+    return STRATEGIES.filter((strategy) => options.agents?.includes(strategy.id));
+  }
+
+  if (!env.isInteractive || options.yes) {
+    log.info('Skipping AI agent setup: no --agents provided in non-interactive mode or with --yes.');
+    return [];
+  }
+
+  const detected = detectAgents(env);
+  if (detected.length === 0) {
+    const selected = await multiselect({
+      message: 'Which AI agent(s) should be configured for letsrunit MCP + skill?',
+      options: STRATEGIES.map((strategy) => ({ value: strategy.id, label: strategy.label })),
+      required: false,
+    });
+    if (!selected || selected.length === 0) return [];
+    return STRATEGIES.filter((strategy) => (selected as AgentId[]).includes(strategy.id));
+  }
+
+  if (detected.length === 1) {
+    const strategy = detected[0];
+    const proceed = await confirm({ message: `Detected ${strategy.label}. Configure letsrunit for it?`, initialValue: true });
+    return proceed === true ? [strategy] : [];
+  }
+
+  const selected = await multiselect({
+    message: 'Multiple AI agents detected. Select which agent(s) to configure:',
+    options: detected.map((strategy) => ({ value: strategy.id, label: strategy.label, hint: strategy.id })),
+    required: false,
+  });
+
+  if (!selected || selected.length === 0) return [];
+  return detected.filter((strategy) => (selected as AgentId[]).includes(strategy.id));
+}
+
+export async function setupAgents(
+  env: Pick<Environment, 'cwd' | 'isInteractive'>,
+  options: { agents?: AgentId[]; yes?: boolean; noMcp?: boolean },
+): Promise<void> {
+  if (options.noMcp) {
+    log.info('Skipped AI agent setup because MCP installation is disabled (--no-mcp).');
+    return;
+  }
+
+  const strategies = await resolveAgentStrategies(env, options);
+  for (const strategy of strategies) {
+    const changedMcp = strategy.configureMcp(env);
+    const changedSkill = strategy.installSkill(env);
+    if (changedMcp === 'skipped') log.info(`${strategy.label}: MCP config already up to date.`);
+    else log.success(`${strategy.label}: MCP config ${changedMcp}.`);
+
+    if (changedSkill === 'skipped') log.info(`${strategy.label}: skill already installed or unavailable.`);
+    else log.success(`${strategy.label}: skill installed.`);
+  }
+}

--- a/packages/letsrunit/src/setup/agents.ts
+++ b/packages/letsrunit/src/setup/agents.ts
@@ -1,4 +1,4 @@
-import { confirm, log, multiselect } from '@clack/prompts';
+import { log } from '@clack/prompts';
 import type { Environment } from '../detect.js';
 import { claudeStrategy } from './agents/claude.js';
 import { codexStrategy } from './agents/codex.js';
@@ -30,60 +30,34 @@ export function parseAgents(value: string | undefined): AgentId[] {
   return [...new Set(ids)] as AgentId[];
 }
 
-function detectAgents(env: Pick<Environment, 'cwd'>): AgentStrategy[] {
-  return STRATEGIES.filter((strategy) => strategy.detect(env));
+export function getAgentCatalog(): Array<{ id: AgentId; label: string }> {
+  return STRATEGIES.map((strategy) => ({ id: strategy.id, label: strategy.label }));
 }
 
-async function resolveAgentStrategies(
-  env: Pick<Environment, 'cwd' | 'isInteractive'>,
-  options: { agents?: AgentId[]; yes?: boolean },
-): Promise<AgentStrategy[]> {
-  if (options.agents && options.agents.length > 0) {
-    return STRATEGIES.filter((strategy) => options.agents?.includes(strategy.id));
-  }
+export function detectAgentIds(env: Pick<Environment, 'cwd'>): AgentId[] {
+  return STRATEGIES.filter((strategy) => strategy.detect(env)).map((strategy) => strategy.id);
+}
 
-  if (!env.isInteractive || options.yes) {
-    log.info('Skipping AI agent setup: no --agents provided in non-interactive mode or with --yes.');
-    return [];
-  }
-
-  const detected = detectAgents(env);
-  if (detected.length === 0) {
-    const selected = await multiselect({
-      message: 'Which AI agent(s) should be configured for letsrunit MCP + skill?',
-      options: STRATEGIES.map((strategy) => ({ value: strategy.id, label: strategy.label })),
-      required: false,
-    });
-    if (!selected || selected.length === 0) return [];
-    return STRATEGIES.filter((strategy) => (selected as AgentId[]).includes(strategy.id));
-  }
-
-  if (detected.length === 1) {
-    const strategy = detected[0];
-    const proceed = await confirm({ message: `Detected ${strategy.label}. Configure letsrunit for it?`, initialValue: true });
-    return proceed === true ? [strategy] : [];
-  }
-
-  const selected = await multiselect({
-    message: 'Multiple AI agents detected. Select which agent(s) to configure:',
-    options: detected.map((strategy) => ({ value: strategy.id, label: strategy.label, hint: strategy.id })),
-    required: false,
-  });
-
-  if (!selected || selected.length === 0) return [];
-  return detected.filter((strategy) => (selected as AgentId[]).includes(strategy.id));
+function resolveStrategies(ids: AgentId[]): AgentStrategy[] {
+  return STRATEGIES.filter((strategy) => ids.includes(strategy.id));
 }
 
 export async function setupAgents(
-  env: Pick<Environment, 'cwd' | 'isInteractive'>,
-  options: { agents?: AgentId[]; yes?: boolean; noMcp?: boolean },
+  env: Pick<Environment, 'cwd'>,
+  options: { agents?: AgentId[]; noMcp?: boolean },
 ): Promise<void> {
   if (options.noMcp) {
     log.info('Skipped AI agent setup because MCP installation is disabled (--no-mcp).');
     return;
   }
 
-  const strategies = await resolveAgentStrategies(env, options);
+  const agentIds = options.agents ?? [];
+  if (agentIds.length === 0) {
+    log.info('Skipped AI agent setup.');
+    return;
+  }
+
+  const strategies = resolveStrategies(agentIds);
   for (const strategy of strategies) {
     const changedMcp = strategy.configureMcp(env);
     const changedSkill = strategy.installSkill(env);

--- a/packages/letsrunit/src/setup/agents/claude.ts
+++ b/packages/letsrunit/src/setup/agents/claude.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureJsonMcpConfig, ensureSkillFile, hasAnyPath } from './shared.js';
+
+export const claudeStrategy: AgentStrategy = {
+  id: 'claude',
+  label: 'Claude Code',
+  detect: ({ cwd }) => hasAnyPath([join(cwd, '.claude'), join(cwd, 'CLAUDE.md')]),
+  configureMcp: ({ cwd }) => ensureJsonMcpConfig(join(cwd, '.mcp.json')),
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/agents/codex.ts
+++ b/packages/letsrunit/src/setup/agents/codex.ts
@@ -1,6 +1,34 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AgentStrategy } from './types.js';
-import { ensureCodexToml, ensureSkillFile, homePath, projectInCodexConfig } from './shared.js';
+import { ensureSkillFile, homePath } from './shared.js';
+
+const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "./node_modules/.bin/letsrunit-mcp"\n\n[mcp_servers.letsrunit.env]\nLETSRUNIT_MCP_RUNTIME_MODE = "project"\n`;
+
+export function ensureCodexToml(path: string): 'created' | 'updated' | 'skipped' {
+  if (!existsSync(path)) {
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, `${TOML_BLOCK}\n`, 'utf-8');
+    return 'created';
+  }
+
+  const content = readFileSync(path, 'utf-8');
+  if (/\[mcp_servers\.letsrunit\]/.test(content)) {
+    return 'skipped';
+  }
+
+  const separator = content.endsWith('\n') ? '' : '\n';
+  writeFileSync(path, `${content}${separator}\n${TOML_BLOCK}\n`, 'utf-8');
+  return 'updated';
+}
+
+export function projectInCodexConfig(path: string, cwd: string): boolean {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, 'utf-8');
+  const escaped = cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\[projects\\."${escaped}"\\]`);
+  return pattern.test(content);
+}
 
 export const codexStrategy: AgentStrategy = {
   id: 'codex',

--- a/packages/letsrunit/src/setup/agents/codex.ts
+++ b/packages/letsrunit/src/setup/agents/codex.ts
@@ -1,0 +1,24 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureCodexToml, ensureSkillFile, homePath, projectInCodexConfig } from './shared.js';
+
+export const codexStrategy: AgentStrategy = {
+  id: 'codex',
+  label: 'Codex CLI',
+  detect: ({ cwd }) => {
+    const localConfig = join(cwd, '.codex', 'config.toml');
+    const homeConfig = homePath('.codex', 'config.toml');
+    if (projectInCodexConfig(homeConfig, cwd)) return true;
+    if (projectInCodexConfig(localConfig, cwd)) return true;
+    return false;
+  },
+  configureMcp: ({ cwd }) => {
+    const localConfig = join(cwd, '.codex', 'config.toml');
+    const homeConfig = homePath('.codex', 'config.toml');
+    if (projectInCodexConfig(homeConfig, cwd) || !projectInCodexConfig(localConfig, cwd)) {
+      return ensureCodexToml(homeConfig);
+    }
+    return ensureCodexToml(localConfig);
+  },
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/agents/copilot.ts
+++ b/packages/letsrunit/src/setup/agents/copilot.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureJsonMcpConfig, ensureSkillFile, hasAnyPath } from './shared.js';
+
+export const copilotStrategy: AgentStrategy = {
+  id: 'copilot',
+  label: 'GitHub Copilot',
+  detect: ({ cwd }) => hasAnyPath([join(cwd, '.github', 'copilot-instructions.md'), join(cwd, '.vscode')]),
+  configureMcp: ({ cwd }) => ensureJsonMcpConfig(join(cwd, '.mcp.json')),
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/agents/cursor.ts
+++ b/packages/letsrunit/src/setup/agents/cursor.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureJsonMcpConfig, ensureSkillFile, hasAnyPath } from './shared.js';
+
+export const cursorStrategy: AgentStrategy = {
+  id: 'cursor',
+  label: 'Cursor',
+  detect: ({ cwd }) => hasAnyPath([join(cwd, '.cursor'), join(cwd, '.cursor', 'mcp.json')]),
+  configureMcp: ({ cwd }) => ensureJsonMcpConfig(join(cwd, '.cursor', 'mcp.json')),
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/agents/fallback-skill.ts
+++ b/packages/letsrunit/src/setup/agents/fallback-skill.ts
@@ -1,0 +1,15 @@
+export const FALLBACK_SKILL = `---
+name: letsrunit
+description: Generate and execute browser tests using Gherkin (Given/When/Then) syntax via a real Playwright browser. Use when asked to write, run, or debug browser tests, or to automate and verify web UI behaviour.
+compatibility: Requires the letsrunit MCP server to be configured.
+---
+
+Use the letsrunit MCP tools to validate browser behavior and save passing scenarios as .feature files.
+
+Workflow:
+1. Start a session with letsrunit_session_start.
+2. List available steps with letsrunit_list_steps.
+3. Run scenario steps with letsrunit_run.
+4. Inspect state with letsrunit_snapshot and letsrunit_screenshot.
+5. Close with letsrunit_session_close.
+`;

--- a/packages/letsrunit/src/setup/agents/gemini.ts
+++ b/packages/letsrunit/src/setup/agents/gemini.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureJsonMcpConfig, ensureSkillFile, hasAnyPath } from './shared.js';
+
+export const geminiStrategy: AgentStrategy = {
+  id: 'gemini',
+  label: 'Gemini CLI',
+  detect: ({ cwd }) => hasAnyPath([join(cwd, '.gemini'), join(cwd, 'GEMINI.md')]),
+  configureMcp: ({ cwd }) => ensureJsonMcpConfig(join(cwd, '.mcp.json')),
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/agents/shared.ts
+++ b/packages/letsrunit/src/setup/agents/shared.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { FALLBACK_SKILL } from './fallback-skill.js';
+
+const MCP_JSON_ENTRY = {
+  command: 'npx',
+  args: ['-y', '@letsrunit/mcp-server@latest'],
+};
+
+export function hasPath(path: string): boolean {
+  return existsSync(path);
+}
+
+export function hasAnyPath(paths: string[]): boolean {
+  return paths.some((path) => existsSync(path));
+}
+
+export function homePath(...parts: string[]): string {
+  return join(homedir(), ...parts);
+}
+
+function sortObject(value: Record<string, unknown>): Record<string, unknown> {
+  const entries = Object.entries(value).sort(([a], [b]) => a.localeCompare(b));
+  return Object.fromEntries(entries);
+}
+
+export function ensureJsonMcpConfig(path: string): 'created' | 'updated' | 'skipped' {
+  const existed = existsSync(path);
+  let parsed: { mcpServers?: Record<string, unknown> } = {};
+  if (existsSync(path)) {
+    try {
+      parsed = JSON.parse(readFileSync(path, 'utf-8')) as { mcpServers?: Record<string, unknown> };
+    } catch {
+      parsed = {};
+    }
+  }
+
+  const current = parsed.mcpServers?.letsrunit;
+  const unchanged =
+    current &&
+    typeof current === 'object' &&
+    JSON.stringify(current) === JSON.stringify(MCP_JSON_ENTRY) &&
+    parsed.mcpServers;
+
+  if (unchanged) return 'skipped';
+
+  const mcpServers = sortObject({ ...(parsed.mcpServers ?? {}), letsrunit: MCP_JSON_ENTRY });
+  const next = { ...parsed, mcpServers };
+
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`, 'utf-8');
+  return existed ? 'updated' : 'created';
+}
+
+const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "npx"\nargs = ["-y", "@letsrunit/mcp-server@latest"]\n`;
+
+export function ensureCodexToml(path: string): 'created' | 'updated' | 'skipped' {
+  if (!existsSync(path)) {
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, `${TOML_BLOCK}\n`, 'utf-8');
+    return 'created';
+  }
+
+  const content = readFileSync(path, 'utf-8');
+  if (/\[mcp_servers\.letsrunit\]/.test(content)) {
+    return 'skipped';
+  }
+
+  const separator = content.endsWith('\n') ? '' : '\n';
+  writeFileSync(path, `${content}${separator}\n${TOML_BLOCK}\n`, 'utf-8');
+  return 'updated';
+}
+
+export function projectInCodexConfig(path: string, cwd: string): boolean {
+  if (!existsSync(path)) return false;
+  const content = readFileSync(path, 'utf-8');
+  const escaped = cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\[projects\\."${escaped}"\\]`);
+  return pattern.test(content);
+}
+
+export function ensureSkillFile(cwd: string): 'installed' | 'skipped' {
+  const destination = join(cwd, '.agents', 'skills', 'letsrunit', 'SKILL.md');
+  const source = join(cwd, 'node_modules', 'letsrunit');
+  const localSource = join(cwd, 'agent', 'skills', 'letsrunit', 'SKILL.md');
+
+  let sourcePath = localSource;
+  if (!existsSync(sourcePath)) {
+    // fallback for normal package usage when source repo isn't present
+    sourcePath = join(source, 'agent', 'skills', 'letsrunit', 'SKILL.md');
+  }
+
+  const sourceContent = existsSync(sourcePath) ? readFileSync(sourcePath, 'utf-8') : FALLBACK_SKILL;
+  if (existsSync(destination)) {
+    const current = readFileSync(destination, 'utf-8');
+    if (current === sourceContent) return 'skipped';
+  }
+
+  mkdirSync(join(destination, '..'), { recursive: true });
+  writeFileSync(destination, sourceContent, 'utf-8');
+  return 'installed';
+}

--- a/packages/letsrunit/src/setup/agents/shared.ts
+++ b/packages/letsrunit/src/setup/agents/shared.ts
@@ -55,33 +55,6 @@ export function ensureJsonMcpConfig(path: string): 'created' | 'updated' | 'skip
   return existed ? 'updated' : 'created';
 }
 
-const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "./node_modules/.bin/letsrunit-mcp"\n\n[mcp_servers.letsrunit.env]\nLETSRUNIT_MCP_RUNTIME_MODE = "project"\n`;
-
-export function ensureCodexToml(path: string): 'created' | 'updated' | 'skipped' {
-  if (!existsSync(path)) {
-    mkdirSync(join(path, '..'), { recursive: true });
-    writeFileSync(path, `${TOML_BLOCK}\n`, 'utf-8');
-    return 'created';
-  }
-
-  const content = readFileSync(path, 'utf-8');
-  if (/\[mcp_servers\.letsrunit\]/.test(content)) {
-    return 'skipped';
-  }
-
-  const separator = content.endsWith('\n') ? '' : '\n';
-  writeFileSync(path, `${content}${separator}\n${TOML_BLOCK}\n`, 'utf-8');
-  return 'updated';
-}
-
-export function projectInCodexConfig(path: string, cwd: string): boolean {
-  if (!existsSync(path)) return false;
-  const content = readFileSync(path, 'utf-8');
-  const escaped = cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`\\[projects\\."${escaped}"\\]`);
-  return pattern.test(content);
-}
-
 export function ensureSkillFile(cwd: string): 'installed' | 'skipped' {
   const destination = join(cwd, '.agents', 'skills', 'letsrunit', 'SKILL.md');
   const source = join(cwd, 'node_modules', 'letsrunit');

--- a/packages/letsrunit/src/setup/agents/shared.ts
+++ b/packages/letsrunit/src/setup/agents/shared.ts
@@ -4,8 +4,10 @@ import { join } from 'node:path';
 import { FALLBACK_SKILL } from './fallback-skill.js';
 
 const MCP_JSON_ENTRY = {
-  command: 'npx',
-  args: ['-y', '@letsrunit/mcp-server@latest'],
+  command: './node_modules/.bin/letsrunit-mcp',
+  env: {
+    LETSRUNIT_MCP_RUNTIME_MODE: 'project',
+  },
 };
 
 export function hasPath(path: string): boolean {
@@ -53,7 +55,7 @@ export function ensureJsonMcpConfig(path: string): 'created' | 'updated' | 'skip
   return existed ? 'updated' : 'created';
 }
 
-const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "npx"\nargs = ["-y", "@letsrunit/mcp-server@latest"]\n`;
+const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "./node_modules/.bin/letsrunit-mcp"\n\n[mcp_servers.letsrunit.env]\nLETSRUNIT_MCP_RUNTIME_MODE = "project"\n`;
 
 export function ensureCodexToml(path: string): 'created' | 'updated' | 'skipped' {
   if (!existsSync(path)) {

--- a/packages/letsrunit/src/setup/agents/types.ts
+++ b/packages/letsrunit/src/setup/agents/types.ts
@@ -1,0 +1,13 @@
+import type { Environment } from '../../detect.js';
+
+export const AGENT_IDS = ['codex', 'cursor', 'claude', 'copilot', 'gemini', 'windsurf'] as const;
+
+export type AgentId = (typeof AGENT_IDS)[number];
+
+export interface AgentStrategy {
+  id: AgentId;
+  label: string;
+  detect(env: Pick<Environment, 'cwd'>): boolean;
+  configureMcp(env: Pick<Environment, 'cwd'>): 'created' | 'updated' | 'skipped';
+  installSkill(env: Pick<Environment, 'cwd'>): 'installed' | 'skipped';
+}

--- a/packages/letsrunit/src/setup/agents/windsurf.ts
+++ b/packages/letsrunit/src/setup/agents/windsurf.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import type { AgentStrategy } from './types.js';
+import { ensureJsonMcpConfig, ensureSkillFile, hasAnyPath } from './shared.js';
+
+export const windsurfStrategy: AgentStrategy = {
+  id: 'windsurf',
+  label: 'Windsurf',
+  detect: ({ cwd }) => hasAnyPath([join(cwd, '.windsurf'), join(cwd, '.codeium')]),
+  configureMcp: ({ cwd }) => ensureJsonMcpConfig(join(cwd, '.mcp.json')),
+  installSkill: ({ cwd }) => ensureSkillFile(cwd),
+};

--- a/packages/letsrunit/src/setup/ci-workflow-plan.ts
+++ b/packages/letsrunit/src/setup/ci-workflow-plan.ts
@@ -1,0 +1,276 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Environment, PackageManager } from '../detect.js';
+import { detectAppTarget, type DetectionResult as ProjectDetectionResult } from './project-app.js';
+
+export type DetectionResult<T> = ProjectDetectionResult<T>;
+
+export interface CiWorkflowPlan {
+  nodeVersion: number;
+  packageManager: PackageManager;
+  installCommand: string;
+  runCucumberCommand: string;
+  setupNodeBlock: string[];
+  startCommand: DetectionResult<string>;
+  buildCommand: DetectionResult<string | null>;
+  baseUrl: DetectionResult<string>;
+  appPort: DetectionResult<number>;
+  db: DetectionResult<'none' | 'supabase' | 'postgres'>;
+  migrationCommand: DetectionResult<string | null>;
+  todoNotes: string[];
+  serviceYamlLines: string[];
+  dbSetupSteps: string[];
+}
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+const DEFAULT_BASE_URL = 'http://localhost:3000';
+
+function readPackageJson(cwd: string): PackageJson {
+  const pkgPath = join(cwd, 'package.json');
+  if (!existsSync(pkgPath)) return {};
+  try {
+    return JSON.parse(readFileSync(pkgPath, 'utf-8')) as PackageJson;
+  } catch {
+    return {};
+  }
+}
+
+function pmRun(pm: PackageManager, script: string): string {
+  if (pm === 'npm') return `npm run ${script}`;
+  if (pm === 'yarn') return `yarn ${script}`;
+  if (pm === 'pnpm') return `pnpm ${script}`;
+  return `bun run ${script}`;
+}
+
+function setupNodeBlock(pm: PackageManager, nodeVersion: number): { setupNode: string[]; install: string } {
+  if (pm === 'yarn') {
+    return {
+      setupNode: [
+        '      - name: Enable Corepack',
+        '        run: corepack enable',
+        '      - uses: actions/setup-node@v4',
+        '        with:',
+        `          node-version: ${nodeVersion}`,
+        '          cache: yarn',
+      ],
+      install: 'yarn install --immutable',
+    };
+  }
+
+  if (pm === 'pnpm') {
+    return {
+      setupNode: [
+        '      - uses: pnpm/action-setup@v4',
+        '      - uses: actions/setup-node@v4',
+        '        with:',
+        `          node-version: ${nodeVersion}`,
+        '          cache: pnpm',
+      ],
+      install: 'pnpm install --frozen-lockfile',
+    };
+  }
+
+  if (pm === 'bun') {
+    return {
+      setupNode: [
+        '      - uses: oven-sh/setup-bun@v2',
+      ],
+      install: 'bun install --frozen-lockfile',
+    };
+  }
+
+  return {
+    setupNode: [
+      '      - uses: actions/setup-node@v4',
+      '        with:',
+      `          node-version: ${nodeVersion}`,
+      '          cache: npm',
+    ],
+    install: 'npm ci',
+  };
+}
+
+function inferStartCommand(pm: PackageManager, pkg: PackageJson): DetectionResult<string> {
+  const scripts = pkg.scripts ?? {};
+  const ordered = ['start:ci', 'start', 'dev', 'serve', 'preview'];
+
+  for (const name of ordered) {
+    if (scripts[name]) {
+      const confidence = name === 'start:ci' || name === 'start' ? 'high' : 'medium';
+      return { value: pmRun(pm, name), confidence, evidence: [`package.json#scripts.${name}`] };
+    }
+  }
+
+  return {
+    value: pmRun(pm, 'dev'),
+    confidence: 'low',
+    evidence: ['no start-like scripts detected'],
+  };
+}
+
+function inferBuildCommand(pm: PackageManager, pkg: PackageJson): DetectionResult<string | null> {
+  const scripts = pkg.scripts ?? {};
+  if (scripts.build) {
+    return { value: pmRun(pm, 'build'), confidence: 'high', evidence: ['package.json#scripts.build'] };
+  }
+
+  return { value: null, confidence: 'low', evidence: ['no build script detected'] };
+}
+
+function hasAnyDep(pkg: PackageJson, names: string[]): boolean {
+  const deps = pkg.dependencies ?? {};
+  const devDeps = pkg.devDependencies ?? {};
+  for (const name of names) {
+    if (name in deps || name in devDeps) return true;
+  }
+  return false;
+}
+
+function inferMigrationCommand(pm: PackageManager, pkg: PackageJson): DetectionResult<string | null> {
+  const scripts = pkg.scripts ?? {};
+  const ordered = ['db:migrate', 'migrate', 'migrations:run', 'prisma:migrate'];
+  for (const script of ordered) {
+    if (scripts[script]) {
+      return { value: pmRun(pm, script), confidence: 'high', evidence: [`package.json#scripts.${script}`] };
+    }
+  }
+
+  return { value: null, confidence: 'low', evidence: ['no migration script detected'] };
+}
+
+function inferDb(cwd: string, pkg: PackageJson): DetectionResult<'none' | 'supabase' | 'postgres'> {
+  const hasSupabaseDir = existsSync(join(cwd, 'supabase'));
+  const hasSupabaseConfig = existsSync(join(cwd, 'supabase', 'config.toml'));
+  const hasSupabaseDep = hasAnyDep(pkg, ['supabase', '@supabase/supabase-js']);
+  if (hasSupabaseDir || hasSupabaseConfig || hasSupabaseDep) {
+    return {
+      value: 'supabase',
+      confidence: hasSupabaseConfig ? 'high' : 'medium',
+      evidence: [
+        ...(hasSupabaseDir ? ['supabase/'] : []),
+        ...(hasSupabaseConfig ? ['supabase/config.toml'] : []),
+        ...(hasSupabaseDep ? ['supabase dependency'] : []),
+      ],
+    };
+  }
+
+  const hasPg = hasAnyDep(pkg, ['pg', 'postgres', 'typeorm', 'prisma']);
+  if (hasPg) {
+    return { value: 'postgres', confidence: 'medium', evidence: ['postgres-related dependency'] };
+  }
+
+  return { value: 'none', confidence: 'low', evidence: ['no db signals detected'] };
+}
+
+export function buildCiWorkflowPlan(
+  env: Pick<Environment, 'cwd' | 'packageManager' | 'nodeVersion'>,
+  options: { appTarget?: ProjectDetectionResult<{ framework: string; port: number; baseUrl: string }> } = {},
+): CiWorkflowPlan {
+  const pkg = readPackageJson(env.cwd);
+  const setup = setupNodeBlock(env.packageManager, env.nodeVersion);
+  const startCommand = inferStartCommand(env.packageManager, pkg);
+  const buildCommand = inferBuildCommand(env.packageManager, pkg);
+  const appTarget = options.appTarget ?? detectAppTarget(env.cwd);
+  const appPort: DetectionResult<number> = {
+    value: appTarget.value.port,
+    confidence: appTarget.confidence,
+    evidence: [...appTarget.evidence],
+  };
+  const baseUrl: DetectionResult<string> = {
+    value: appTarget.value.baseUrl,
+    confidence: appTarget.confidence,
+    evidence: [...appTarget.evidence],
+  };
+  const db = inferDb(env.cwd, pkg);
+  const migrationCommand = inferMigrationCommand(env.packageManager, pkg);
+
+  const todoNotes: string[] = [];
+  if (startCommand.confidence === 'low') {
+    todoNotes.push('TODO: verify start command (defaulted to dev script).');
+  }
+  if (appPort.confidence === 'low') {
+    todoNotes.push('TODO: verify application port and baseURL.');
+  }
+  if (db.value === 'none') {
+    todoNotes.push('TODO: add DB setup steps if your tests need one.');
+  }
+
+  const serviceYamlLines: string[] = [];
+  const dbSetupSteps: string[] = [];
+
+  if (db.value === 'supabase') {
+    dbSetupSteps.push('      - uses: supabase/setup-cli@v1');
+    dbSetupSteps.push('      - name: Start Supabase');
+    dbSetupSteps.push('        run: supabase start');
+    dbSetupSteps.push('      - name: Apply Supabase migrations');
+    dbSetupSteps.push('        run: supabase db push');
+  }
+
+  if (db.value === 'postgres') {
+    serviceYamlLines.push('    services:');
+    serviceYamlLines.push('      postgres:');
+    serviceYamlLines.push('        image: postgres:16');
+    serviceYamlLines.push('        env:');
+    serviceYamlLines.push('          POSTGRES_USER: postgres');
+    serviceYamlLines.push('          POSTGRES_PASSWORD: postgres');
+    serviceYamlLines.push('          POSTGRES_DB: app');
+    serviceYamlLines.push('        ports:');
+    serviceYamlLines.push('          - 5432:5432');
+    serviceYamlLines.push('        options: >-');
+    serviceYamlLines.push('          --health-cmd "pg_isready -U postgres"');
+    serviceYamlLines.push('          --health-interval 10s');
+    serviceYamlLines.push('          --health-timeout 5s');
+    serviceYamlLines.push('          --health-retries 5');
+
+    if (migrationCommand.value) {
+      dbSetupSteps.push('      - name: Run DB migrations');
+      dbSetupSteps.push(`        run: ${migrationCommand.value}`);
+    } else {
+      todoNotes.push('TODO: add migration step for Postgres.');
+    }
+  }
+
+  return {
+    nodeVersion: env.nodeVersion,
+    packageManager: env.packageManager,
+    installCommand: setup.install,
+    runCucumberCommand: 'npx cucumber-js',
+    setupNodeBlock: setup.setupNode,
+    startCommand,
+    buildCommand,
+    baseUrl,
+    appPort,
+    db,
+    migrationCommand,
+    todoNotes,
+    serviceYamlLines,
+    dbSetupSteps,
+  };
+}
+
+export function updateCucumberBaseUrl(cwd: string, targetUrl: string): 'updated' | 'skipped' {
+  const configPath = join(cwd, 'cucumber.js');
+  if (!existsSync(configPath)) return 'skipped';
+
+  const current = readFileSync(configPath, 'utf-8');
+  const match = current.match(/(baseURL\s*:\s*['"])([^'"]+)(['"])/);
+  if (!match) return 'skipped';
+  if (match[2] === targetUrl) return 'skipped';
+
+  const next = current.replace(/(baseURL\s*:\s*['"])([^'"]+)(['"])/, `$1${targetUrl}$3`);
+  if (next === current) return 'skipped';
+
+  // Keep this update narrowly scoped to baseURL replacement.
+  writeFileSync(configPath, next, 'utf-8');
+
+  return 'updated';
+}
+
+export function recommendedBaseUrl(plan: CiWorkflowPlan): string {
+  return plan.baseUrl.value || DEFAULT_BASE_URL;
+}

--- a/packages/letsrunit/src/setup/cucumber.ts
+++ b/packages/letsrunit/src/setup/cucumber.ts
@@ -4,12 +4,13 @@ import { type Environment, execPm } from '../detect.js';
 
 const BDD_IMPORT = '@letsrunit/cucumber';
 
-const CUCUMBER_CONFIG = `import { isAgentEnvironment, resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
+function cucumberConfig(baseUrl: string): string {
+  return `import { isAgentEnvironment, resolveDebugWorldParameters } from '@letsrunit/cucumber/config';
 
 const { failFast, worldParameters } = resolveDebugWorldParameters({
   argv: process.argv,
   baseWorldParameters: {
-    baseURL: 'http://localhost:3000',
+    baseURL: '${baseUrl}',
   },
 });
 
@@ -35,6 +36,7 @@ export default {
   },
 };
 `;
+}
 
 const SUPPORT_FILE = `import { setDefaultTimeout } from '@cucumber/cucumber';
 import '${BDD_IMPORT}';
@@ -88,7 +90,7 @@ function installBdd(env: Pick<Environment, 'packageManager' | 'cwd'>): boolean {
   return true;
 }
 
-function setupCucumberConfig({ cwd }: Pick<Environment, 'cwd'>): CucumberConfigResult {
+function setupCucumberConfig({ cwd }: Pick<Environment, 'cwd'>, baseUrl: string): CucumberConfigResult {
   const supportDir = join(cwd, 'features', 'support');
   const supportPath = join(supportDir, 'world.js');
 
@@ -100,7 +102,7 @@ function setupCucumberConfig({ cwd }: Pick<Environment, 'cwd'>): CucumberConfigR
 
   const configPath = join(cwd, 'cucumber.js');
   if (!existsSync(configPath)) {
-    writeFileSync(configPath, CUCUMBER_CONFIG, 'utf-8');
+    writeFileSync(configPath, cucumberConfig(baseUrl), 'utf-8');
   }
 
   mkdirSync(supportDir, { recursive: true });
@@ -130,9 +132,12 @@ function setupFeaturesDir({ cwd }: Pick<Environment, 'cwd'>): boolean {
   return true;
 }
 
-export function setupCucumber(env: Pick<Environment, 'packageManager' | 'cwd'>): CucumberSetupResult {
+export function setupCucumber(
+  env: Pick<Environment, 'packageManager' | 'cwd'>,
+  options: { baseUrl?: string } = {},
+): CucumberSetupResult {
   const bddInstalled = installBdd(env);
-  const configResult = setupCucumberConfig(env);
+  const configResult = setupCucumberConfig(env, options.baseUrl ?? 'http://localhost:3000');
   const featuresCreated = setupFeaturesDir(env);
   return { bddInstalled, configResult, featuresCreated };
 }

--- a/packages/letsrunit/src/setup/github-actions.ts
+++ b/packages/letsrunit/src/setup/github-actions.ts
@@ -1,42 +1,45 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Environment } from '../detect.js';
+import { buildCiWorkflowPlan, type CiWorkflowPlan } from './ci-workflow-plan.js';
+import type { DetectionResult, AppTarget } from './project-app.js';
 
-export type GithubActionsResult = 'created' | 'skipped';
-
-function setupStepsFor({ packageManager, nodeVersion }: Pick<Environment, 'packageManager' | 'nodeVersion'>): string {
-  if (packageManager === 'yarn') return `\
-      - name: Enable Corepack
-        run: corepack enable
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${nodeVersion}
-          cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable`;
-  if (packageManager === 'pnpm') return `\
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${nodeVersion}
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile`;
-  if (packageManager === 'bun') return `\
-      - uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile`;
-  return `\
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${nodeVersion}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci`;
+export interface GithubActionsResult {
+  status: 'created' | 'skipped';
+  plan: CiWorkflowPlan;
 }
 
-function workflowYaml(env: Pick<Environment, 'packageManager' | 'nodeVersion'>): string {
-  const setupSteps = setupStepsFor(env);
+function renderTodoComments(plan: CiWorkflowPlan): string {
+  if (plan.todoNotes.length === 0) return '';
+  const lines = plan.todoNotes.map((todo) => `      # ${todo}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function renderBuildStep(plan: CiWorkflowPlan): string {
+  if (!plan.buildCommand.value) return '';
+  if (plan.buildCommand.confidence !== 'high') return '';
+  return `      - name: Build app
+        run: ${plan.buildCommand.value}
+`;
+}
+
+function renderServiceBlock(plan: CiWorkflowPlan): string {
+  if (plan.serviceYamlLines.length === 0) return '';
+  return `${plan.serviceYamlLines.join('\n')}\n`;
+}
+
+function renderDbSteps(plan: CiWorkflowPlan): string {
+  if (plan.dbSetupSteps.length === 0) return '';
+  return `${plan.dbSetupSteps.join('\n')}\n`;
+}
+
+function workflowYaml(plan: CiWorkflowPlan): string {
+  const setupSteps = plan.setupNodeBlock.join('\n');
+  const serviceBlock = renderServiceBlock(plan);
+  const todoComments = renderTodoComments(plan);
+  const buildStep = renderBuildStep(plan);
+  const dbSteps = renderDbSteps(plan);
+  const waitUrl = `${plan.baseUrl.value.replace(/\/$/, '')}/`;
 
   return `name: Features
 on:
@@ -47,23 +50,37 @@ on:
 jobs:
   features:
     runs-on: ubuntu-latest
+${serviceBlock}    env:
+      BASE_URL: ${plan.baseUrl.value}
     steps:
       - uses: actions/checkout@v4
 ${setupSteps}
+      - name: Install dependencies
+        run: ${plan.installCommand}
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
+      - name: Install wait-on
+        run: npm i -g wait-on
+${buildStep}${dbSteps}${todoComments}      - name: Start app
+        run: ${plan.startCommand.value} &
+      - name: Wait for app
+        run: wait-on ${waitUrl}
       - name: Run features
-        run: npx cucumber-js
+        run: ${plan.runCucumberCommand}
 `;
 }
 
-export function installGithubAction(env: Pick<Environment, 'packageManager' | 'nodeVersion' | 'cwd'>): GithubActionsResult {
+export function installGithubAction(
+  env: Pick<Environment, 'packageManager' | 'nodeVersion' | 'cwd'>,
+  options: { appTarget?: DetectionResult<AppTarget> } = {},
+): GithubActionsResult {
   const workflowDir = join(env.cwd, '.github', 'workflows');
   const workflowPath = join(workflowDir, 'letsrunit.yml');
+  const plan = buildCiWorkflowPlan(env, { appTarget: options.appTarget });
 
-  if (existsSync(workflowPath)) return 'skipped';
+  if (existsSync(workflowPath)) return { status: 'skipped', plan };
 
   mkdirSync(workflowDir, { recursive: true });
-  writeFileSync(workflowPath, workflowYaml(env), 'utf-8');
-  return 'created';
+  writeFileSync(workflowPath, workflowYaml(plan), 'utf-8');
+  return { status: 'created', plan };
 }

--- a/packages/letsrunit/src/setup/project-app.ts
+++ b/packages/letsrunit/src/setup/project-app.ts
@@ -1,0 +1,285 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type DetectionConfidence = 'high' | 'medium' | 'low';
+
+export interface DetectionResult<T> {
+  value: T;
+  confidence: DetectionConfidence;
+  evidence: string[];
+}
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+export interface AppTarget {
+  framework: string;
+  port: number;
+  baseUrl: string;
+}
+
+interface FrameworkMatch {
+  name: string;
+  defaultPort: number;
+  confidence: DetectionConfidence;
+  evidence: string[];
+}
+
+const DEFAULT_PORT = 3000;
+
+const FRAMEWORK_RULES: Array<{ name: string; defaultPort: number; deps: string[]; scriptPatterns?: RegExp[] }> = [
+  { name: 'nextjs', defaultPort: 3000, deps: ['next'], scriptPatterns: [/\bnext\s+(?:dev|start)\b/] },
+  { name: 'vite', defaultPort: 5173, deps: ['vite', '@vitejs/plugin-react', '@vitejs/plugin-vue'], scriptPatterns: [/\bvite\b/] },
+  { name: 'angular', defaultPort: 4200, deps: ['@angular/core', '@angular/cli'], scriptPatterns: [/\bng\s+(?:serve|dev)\b/] },
+  { name: 'nuxt', defaultPort: 3000, deps: ['nuxt'], scriptPatterns: [/\bnuxt\s+(?:dev|start)\b/] },
+  { name: 'sveltekit', defaultPort: 5173, deps: ['@sveltejs/kit'] },
+  { name: 'astro', defaultPort: 4321, deps: ['astro'], scriptPatterns: [/\bastro\s+dev\b/] },
+  { name: 'vue-cli', defaultPort: 8080, deps: ['@vue/cli-service'] },
+  { name: 'create-react-app', defaultPort: 3000, deps: ['react-scripts'] },
+  { name: 'remix', defaultPort: 5173, deps: ['@remix-run/dev'], scriptPatterns: [/\bremix\s+vite:dev\b/] },
+  { name: 'nestjs', defaultPort: 3000, deps: ['@nestjs/core'] },
+];
+
+function readText(path: string): string {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function readPackageJson(cwd: string): PackageJson {
+  const path = join(cwd, 'package.json');
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readText(path)) as PackageJson;
+  } catch {
+    return {};
+  }
+}
+
+function parsePortFromEnvText(text: string): number | null {
+  const match = text.match(/(?:^|\n)\s*(?:PORT|APP_PORT)\s*=\s*['"]?(\d{2,5})['"]?\s*(?:\n|$)/);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parsePortFromScript(script: string): number | null {
+  const envMatch = script.match(/(?:^|\s)PORT\s*=\s*(\d{2,5})(?:\s|$)/);
+  if (envMatch) return Number.parseInt(envMatch[1], 10);
+
+  const longFlag = script.match(/--port(?:=|\s+)(\d{2,5})(?:\s|$)/);
+  if (longFlag) return Number.parseInt(longFlag[1], 10);
+
+  const shortFlag = script.match(/(?:^|\s)-p\s+(\d{2,5})(?:\s|$)/);
+  if (shortFlag) return Number.parseInt(shortFlag[1], 10);
+
+  return null;
+}
+
+function detectFramework(pkg: PackageJson): FrameworkMatch | null {
+  const deps = pkg.dependencies ?? {};
+  const devDeps = pkg.devDependencies ?? {};
+  const scripts = pkg.scripts ?? {};
+
+  for (const fw of FRAMEWORK_RULES) {
+    const depMatch = fw.deps.find((dep) => dep in deps || dep in devDeps);
+    if (depMatch) {
+      return { name: fw.name, defaultPort: fw.defaultPort, confidence: 'high', evidence: [`dependency:${depMatch}`] };
+    }
+  }
+
+  for (const fw of FRAMEWORK_RULES) {
+    if (!fw.scriptPatterns) continue;
+    for (const [name, body] of Object.entries(scripts)) {
+      if (fw.scriptPatterns.some((pattern) => pattern.test(body))) {
+        return { name: fw.name, defaultPort: fw.defaultPort, confidence: 'medium', evidence: [`script:${name}`] };
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractPortByRegex(text: string, regex: RegExp): number | null {
+  const match = text.match(regex);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function detectPortFromViteConfig(cwd: string): DetectionResult<number> | null {
+  const files = ['vite.config.ts', 'vite.config.js', 'vite.config.mts', 'vite.config.mjs', 'vite.config.cts', 'vite.config.cjs'];
+  for (const file of files) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+    const text = readText(path);
+    const port = extractPortByRegex(text, /server\s*:\s*\{[\s\S]*?port\s*:\s*(\d{2,5})/m);
+    if (port) {
+      return { value: port, confidence: 'high', evidence: [file] };
+    }
+  }
+
+  return null;
+}
+
+function detectPortFromAngularConfig(cwd: string): DetectionResult<number> | null {
+  const files = ['angular.json', 'workspace.json'];
+  for (const file of files) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+
+    try {
+      const config = JSON.parse(readText(path)) as {
+        defaultProject?: string;
+        projects?: Record<string, any>;
+      };
+      const projects = config.projects ?? {};
+      const names = [config.defaultProject, ...Object.keys(projects)].filter((v, i, a) => Boolean(v) && a.indexOf(v) === i) as string[];
+
+      for (const name of names) {
+        const project = projects[name] as any;
+        const architect = project?.architect ?? project?.targets;
+        const serve = architect?.serve;
+        const port = serve?.options?.port;
+        if (Number.isFinite(port)) {
+          return { value: Number(port), confidence: 'high', evidence: [`${file}#projects.${name}.architect.serve.options.port`] };
+        }
+
+        const configurations = serve?.configurations ?? {};
+        for (const [configName, cfg] of Object.entries(configurations)) {
+          const candidate = (cfg as any)?.port;
+          if (Number.isFinite(candidate)) {
+            return {
+              value: Number(candidate),
+              confidence: 'medium',
+              evidence: [`${file}#projects.${name}.architect.serve.configurations.${configName}.port`],
+            };
+          }
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function detectPortFromNuxtConfig(cwd: string): DetectionResult<number> | null {
+  const files = ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs', 'nuxt.config.cjs'];
+  for (const file of files) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+
+    const text = readText(path);
+    const devServerPort = extractPortByRegex(text, /devServer\s*:\s*\{[\s\S]*?port\s*:\s*(\d{2,5})/m);
+    if (devServerPort) return { value: devServerPort, confidence: 'high', evidence: [file] };
+
+    const serverPort = extractPortByRegex(text, /server\s*:\s*\{[\s\S]*?port\s*:\s*(\d{2,5})/m);
+    if (serverPort) return { value: serverPort, confidence: 'high', evidence: [file] };
+  }
+
+  return null;
+}
+
+function detectPortFromAstroConfig(cwd: string): DetectionResult<number> | null {
+  const files = ['astro.config.ts', 'astro.config.mjs', 'astro.config.js', 'astro.config.cjs'];
+  for (const file of files) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+    const text = readText(path);
+    const port = extractPortByRegex(text, /server\s*:\s*\{[\s\S]*?port\s*:\s*(\d{2,5})/m);
+    if (port) return { value: port, confidence: 'high', evidence: [file] };
+  }
+
+  return null;
+}
+
+function detectPortFromVueCliConfig(cwd: string): DetectionResult<number> | null {
+  const path = join(cwd, 'vue.config.js');
+  if (!existsSync(path)) return null;
+
+  const text = readText(path);
+  const port = extractPortByRegex(text, /devServer\s*:\s*\{[\s\S]*?port\s*:\s*(\d{2,5})/m);
+  if (!port) return null;
+  return { value: port, confidence: 'high', evidence: ['vue.config.js'] };
+}
+
+function detectPortFromFrameworkConfig(cwd: string, framework: string): DetectionResult<number> | null {
+  if (framework === 'vite' || framework === 'sveltekit' || framework === 'remix') return detectPortFromViteConfig(cwd);
+  if (framework === 'angular') return detectPortFromAngularConfig(cwd);
+  if (framework === 'nuxt') return detectPortFromNuxtConfig(cwd);
+  if (framework === 'astro') return detectPortFromAstroConfig(cwd);
+  if (framework === 'vue-cli') return detectPortFromVueCliConfig(cwd);
+  return null;
+}
+
+function detectPortFromScripts(pkg: PackageJson): DetectionResult<number> | null {
+  const scripts = pkg.scripts ?? {};
+  const orderedScripts = ['start:ci', 'start', 'dev', 'serve', 'preview'];
+
+  for (const name of orderedScripts) {
+    const body = scripts[name];
+    if (!body) continue;
+    const port = parsePortFromScript(body);
+    if (port) {
+      return { value: port, confidence: 'high', evidence: [`package.json#scripts.${name}`] };
+    }
+  }
+
+  return null;
+}
+
+function detectPortFromEnvFiles(cwd: string): DetectionResult<number> | null {
+  const envFiles = ['.env', '.env.local', '.env.development', '.env.test', '.env.ci'];
+  for (const file of envFiles) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+    const port = parsePortFromEnvText(readText(path));
+    if (port) return { value: port, confidence: 'medium', evidence: [file] };
+  }
+
+  return null;
+}
+
+function buildTarget(framework: string, port: DetectionResult<number>): DetectionResult<AppTarget> {
+  return {
+    value: {
+      framework,
+      port: port.value,
+      baseUrl: `http://localhost:${port.value}`,
+    },
+    confidence: port.confidence,
+    evidence: port.evidence,
+  };
+}
+
+export function detectAppTarget(cwd: string): DetectionResult<AppTarget> {
+  const pkg = readPackageJson(cwd);
+  const frameworkMatch = detectFramework(pkg);
+  const framework = frameworkMatch?.name ?? 'unknown';
+
+  const scriptPort = detectPortFromScripts(pkg);
+  if (scriptPort) return buildTarget(framework, scriptPort);
+
+  const configPort = detectPortFromFrameworkConfig(cwd, framework);
+  if (configPort) return buildTarget(framework, configPort);
+
+  const envPort = detectPortFromEnvFiles(cwd);
+  if (envPort) return buildTarget(framework, envPort);
+
+  if (frameworkMatch) {
+    return buildTarget(framework, {
+      value: frameworkMatch.defaultPort,
+      confidence: frameworkMatch.confidence,
+      evidence: [...frameworkMatch.evidence, 'framework default'],
+    });
+  }
+
+  return buildTarget('unknown', { value: DEFAULT_PORT, confidence: 'low', evidence: ['default fallback'] });
+}

--- a/packages/letsrunit/tests/agents.test.ts
+++ b/packages/letsrunit/tests/agents.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { parseAgents, setupAgents } from '../src/setup/agents.js';
-import { ensureCodexToml, ensureJsonMcpConfig, projectInCodexConfig } from '../src/setup/agents/shared.js';
+import { ensureCodexToml, projectInCodexConfig } from '../src/setup/agents/codex.js';
+import { ensureJsonMcpConfig } from '../src/setup/agents/shared.js';
 
 const dirs: string[] = [];
 

--- a/packages/letsrunit/tests/agents.test.ts
+++ b/packages/letsrunit/tests/agents.test.ts
@@ -50,14 +50,19 @@ describe('MCP config writers', () => {
     const result = ensureJsonMcpConfig(path);
     expect(result).toBe('created');
 
-    const json = JSON.parse(readFileSync(path, 'utf-8')) as { mcpServers: Record<string, unknown> };
-    expect(json.mcpServers.letsrunit).toBeDefined();
+    const json = JSON.parse(readFileSync(path, 'utf-8')) as {
+      mcpServers: Record<string, { command: string; env?: Record<string, string> }>;
+    };
+    expect(json.mcpServers.letsrunit.command).toBe('./node_modules/.bin/letsrunit-mcp');
+    expect(json.mcpServers.letsrunit.env?.LETSRUNIT_MCP_RUNTIME_MODE).toBe('project');
   });
 
   it('creates codex toml block and skips if already configured', () => {
     const dir = makeDir();
     const path = join(dir, 'config.toml');
     expect(ensureCodexToml(path)).toBe('created');
+    expect(readFileSync(path, 'utf-8')).toContain('command = "./node_modules/.bin/letsrunit-mcp"');
+    expect(readFileSync(path, 'utf-8')).toContain('LETSRUNIT_MCP_RUNTIME_MODE = "project"');
     expect(ensureCodexToml(path)).toBe('skipped');
   });
 });
@@ -81,8 +86,11 @@ describe('setupAgents behavior', () => {
     await setupAgents({ cwd, isInteractive: false }, { yes: true, noMcp: false, agents: ['cursor'] });
 
     const configPath = join(cwd, '.cursor', 'mcp.json');
-    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { mcpServers: Record<string, unknown> };
-    expect(config.mcpServers.letsrunit).toBeDefined();
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
+      mcpServers: Record<string, { command: string; env?: Record<string, string> }>;
+    };
+    expect(config.mcpServers.letsrunit.command).toBe('./node_modules/.bin/letsrunit-mcp');
+    expect(config.mcpServers.letsrunit.env?.LETSRUNIT_MCP_RUNTIME_MODE).toBe('project');
 
     const skillPath = join(cwd, '.agents', 'skills', 'letsrunit', 'SKILL.md');
     expect(readFileSync(skillPath, 'utf-8')).toBe('demo');

--- a/packages/letsrunit/tests/agents.test.ts
+++ b/packages/letsrunit/tests/agents.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { parseAgents, setupAgents } from '../src/setup/agents.js';
+import { ensureCodexToml, ensureJsonMcpConfig, projectInCodexConfig } from '../src/setup/agents/shared.js';
+
+const dirs: string[] = [];
+
+function makeDir(): string {
+  const path = mkdtempSync(join(tmpdir(), 'letsrunit-agents-'));
+  dirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('parseAgents', () => {
+  it('parses comma separated list', () => {
+    expect(parseAgents('codex,cursor')).toEqual(['codex', 'cursor']);
+  });
+
+  it('deduplicates values', () => {
+    expect(parseAgents('codex,codex')).toEqual(['codex']);
+  });
+
+  it('throws for unknown value', () => {
+    expect(() => parseAgents('unknown')).toThrow(/Unknown agent/);
+  });
+});
+
+describe('codex project detection', () => {
+  it('detects project in config toml', () => {
+    const dir = makeDir();
+    const path = join(dir, 'config.toml');
+    const cwd = '/tmp/example';
+    writeFileSync(path, `[projects."${cwd}"]\ntrust_level = "trusted"\n`, 'utf-8');
+    expect(projectInCodexConfig(path, cwd)).toBe(true);
+  });
+});
+
+describe('MCP config writers', () => {
+  it('creates json mcp config', () => {
+    const dir = makeDir();
+    const path = join(dir, '.cursor', 'mcp.json');
+    const result = ensureJsonMcpConfig(path);
+    expect(result).toBe('created');
+
+    const json = JSON.parse(readFileSync(path, 'utf-8')) as { mcpServers: Record<string, unknown> };
+    expect(json.mcpServers.letsrunit).toBeDefined();
+  });
+
+  it('creates codex toml block and skips if already configured', () => {
+    const dir = makeDir();
+    const path = join(dir, 'config.toml');
+    expect(ensureCodexToml(path)).toBe('created');
+    expect(ensureCodexToml(path)).toBe('skipped');
+  });
+});
+
+describe('setupAgents behavior', () => {
+  it('skips configuration in non-interactive mode without --agents', async () => {
+    const cwd = makeDir();
+    mkdirSync(join(cwd, 'agent', 'skills', 'letsrunit'), { recursive: true });
+    writeFileSync(join(cwd, 'agent', 'skills', 'letsrunit', 'SKILL.md'), 'demo', 'utf-8');
+
+    await setupAgents({ cwd, isInteractive: false }, { yes: false, noMcp: false, agents: [] });
+
+    expect(() => readFileSync(join(cwd, '.mcp.json'), 'utf-8')).toThrow();
+  });
+
+  it('configures selected agents explicitly', async () => {
+    const cwd = makeDir();
+    mkdirSync(join(cwd, 'agent', 'skills', 'letsrunit'), { recursive: true });
+    writeFileSync(join(cwd, 'agent', 'skills', 'letsrunit', 'SKILL.md'), 'demo', 'utf-8');
+
+    await setupAgents({ cwd, isInteractive: false }, { yes: true, noMcp: false, agents: ['cursor'] });
+
+    const configPath = join(cwd, '.cursor', 'mcp.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { mcpServers: Record<string, unknown> };
+    expect(config.mcpServers.letsrunit).toBeDefined();
+
+    const skillPath = join(cwd, '.agents', 'skills', 'letsrunit', 'SKILL.md');
+    expect(readFileSync(skillPath, 'utf-8')).toBe('demo');
+  });
+});

--- a/packages/letsrunit/tests/ci-workflow-plan.test.ts
+++ b/packages/letsrunit/tests/ci-workflow-plan.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildCiWorkflowPlan, updateCucumberBaseUrl } from '../src/setup/ci-workflow-plan.js';
+import type { PackageManager } from '../src/detect.js';
+
+const dirs: string[] = [];
+
+function makeDir(): string {
+  const path = mkdtempSync(join(tmpdir(), 'letsrunit-ci-plan-'));
+  dirs.push(path);
+  return path;
+}
+
+function writePackageJson(cwd: string, data: object): void {
+  writeFileSync(join(cwd, 'package.json'), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function planFor(cwd: string, packageManager: PackageManager = 'npm') {
+  return buildCiWorkflowPlan({ cwd, packageManager, nodeVersion: 22 });
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('buildCiWorkflowPlan', () => {
+  it('maps package manager install/run commands', () => {
+    const cwd = makeDir();
+    writePackageJson(cwd, { scripts: { start: 'node server.js' } });
+
+    const npmPlan = planFor(cwd, 'npm');
+    const yarnPlan = planFor(cwd, 'yarn');
+    const pnpmPlan = planFor(cwd, 'pnpm');
+    const bunPlan = planFor(cwd, 'bun');
+
+    expect(npmPlan.installCommand).toBe('npm ci');
+    expect(yarnPlan.installCommand).toBe('yarn install --immutable');
+    expect(pnpmPlan.installCommand).toBe('pnpm install --frozen-lockfile');
+    expect(bunPlan.installCommand).toBe('bun install --frozen-lockfile');
+
+    expect(yarnPlan.startCommand.value).toBe('yarn start');
+    expect(pnpmPlan.startCommand.value).toBe('pnpm start');
+    expect(bunPlan.startCommand.value).toBe('bun run start');
+  });
+
+  it('uses start command precedence with low-confidence fallback', () => {
+    const cwd = makeDir();
+    writePackageJson(cwd, { scripts: { dev: 'vite' } });
+    let plan = planFor(cwd);
+    expect(plan.startCommand.value).toBe('npm run dev');
+    expect(plan.startCommand.confidence).toBe('medium');
+
+    writePackageJson(cwd, { scripts: {} });
+    plan = planFor(cwd);
+    expect(plan.startCommand.value).toBe('npm run dev');
+    expect(plan.startCommand.confidence).toBe('low');
+    expect(plan.todoNotes.join('\n')).toContain('verify start command');
+  });
+
+  it('uses provided app target for port and baseURL', () => {
+    const cwd = makeDir();
+    writePackageJson(cwd, { scripts: { start: 'node server.js' } });
+
+    const plan = buildCiWorkflowPlan(
+      { cwd, packageManager: 'npm', nodeVersion: 22 },
+      {
+        appTarget: {
+          value: { framework: 'vite', port: 5173, baseUrl: 'http://localhost:5173' },
+          confidence: 'high',
+          evidence: ['dependency:vite'],
+        },
+      },
+    );
+    expect(plan.appPort.value).toBe(5173);
+    expect(plan.baseUrl.value).toBe('http://localhost:5173');
+    expect(plan.appPort.confidence).toBe('high');
+  });
+
+  it('detects supabase and postgres workflows', () => {
+    const supabaseCwd = makeDir();
+    writePackageJson(supabaseCwd, { scripts: { start: 'node server.js' } });
+    mkdirSync(join(supabaseCwd, 'supabase'), { recursive: true });
+    writeFileSync(join(supabaseCwd, 'supabase', 'config.toml'), 'project_id = "demo"', 'utf-8');
+
+    const supabasePlan = planFor(supabaseCwd);
+    expect(supabasePlan.db.value).toBe('supabase');
+    expect(supabasePlan.dbSetupSteps.join('\n')).toContain('supabase start');
+
+    const postgresCwd = makeDir();
+    writePackageJson(postgresCwd, {
+      scripts: { start: 'node server.js', 'db:migrate': 'prisma migrate deploy' },
+      dependencies: { pg: '^8.0.0' },
+    });
+
+    const postgresPlan = planFor(postgresCwd);
+    expect(postgresPlan.db.value).toBe('postgres');
+    expect(postgresPlan.serviceYamlLines.join('\n')).toContain('postgres:16');
+    expect(postgresPlan.dbSetupSteps.join('\n')).toContain('npm run db:migrate');
+  });
+});
+
+describe('updateCucumberBaseUrl', () => {
+  it('updates existing baseURL value', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'cucumber.js'),
+      "export default { worldParameters: { baseURL: 'http://localhost:3000' } };",
+      'utf-8',
+    );
+
+    expect(updateCucumberBaseUrl(cwd, 'http://localhost:4100')).toBe('updated');
+    expect(readFileSync(join(cwd, 'cucumber.js'), 'utf-8')).toContain('http://localhost:4100');
+  });
+});

--- a/packages/letsrunit/tests/github-actions.test.ts
+++ b/packages/letsrunit/tests/github-actions.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installGithubAction } from '../src/setup/github-actions.js';
+
+const dirs: string[] = [];
+
+function makeDir(): string {
+  const path = mkdtempSync(join(tmpdir(), 'letsrunit-gha-'));
+  dirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('installGithubAction', () => {
+  it('creates workflow once and skips when existing', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'package.json'),
+      JSON.stringify({ scripts: { start: 'node server.js', build: 'vite build' } }, null, 2),
+      'utf-8',
+    );
+    writeFileSync(join(cwd, 'cucumber.js'), "export default { worldParameters: { baseURL: 'http://localhost:3000' } };", 'utf-8');
+
+    const first = installGithubAction({ cwd, packageManager: 'npm', nodeVersion: 22 });
+    const second = installGithubAction({ cwd, packageManager: 'npm', nodeVersion: 22 });
+
+    expect(first.status).toBe('created');
+    expect(second.status).toBe('skipped');
+
+    const workflow = readFileSync(join(cwd, '.github', 'workflows', 'letsrunit.yml'), 'utf-8');
+    expect(workflow).toContain('run: npm ci');
+    expect(workflow).toContain('run: npm run start &');
+    expect(workflow).toContain('wait-on http://localhost:5173/');
+    expect(workflow).toContain('run: npm run build');
+  });
+
+  it('includes TODO comments for low-confidence projects', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ scripts: {} }, null, 2), 'utf-8');
+
+    const result = installGithubAction({ cwd, packageManager: 'npm', nodeVersion: 22 });
+    expect(result.status).toBe('created');
+
+    const workflow = readFileSync(join(cwd, '.github', 'workflows', 'letsrunit.yml'), 'utf-8');
+    expect(workflow).toContain('TODO: verify start command');
+    expect(workflow).toContain('TODO: verify application port and baseURL.');
+  });
+});

--- a/packages/letsrunit/tests/project-app.test.ts
+++ b/packages/letsrunit/tests/project-app.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectAppTarget } from '../src/setup/project-app.js';
+
+const dirs: string[] = [];
+
+function makeDir(): string {
+  const path = mkdtempSync(join(tmpdir(), 'letsrunit-app-target-'));
+  dirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('detectAppTarget', () => {
+  it('detects vite port from vite.config.ts', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ devDependencies: { vite: '^7.0.0' } }), 'utf-8');
+    writeFileSync(
+      join(cwd, 'vite.config.ts'),
+      "export default { server: { port: 6123 } };\n",
+      'utf-8',
+    );
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.framework).toBe('vite');
+    expect(result.value.port).toBe(6123);
+  });
+
+  it('detects angular port from angular.json', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { '@angular/core': '^20.0.0' } }), 'utf-8');
+    writeFileSync(
+      join(cwd, 'angular.json'),
+      JSON.stringify(
+        {
+          defaultProject: 'app',
+          projects: {
+            app: {
+              architect: {
+                serve: {
+                  options: {
+                    port: 4300,
+                  },
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.framework).toBe('angular');
+    expect(result.value.port).toBe(4300);
+  });
+
+  it('detects nuxt devServer port from nuxt.config.ts', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { nuxt: '^4.0.0' } }), 'utf-8');
+    writeFileSync(join(cwd, 'nuxt.config.ts'), "export default defineNuxtConfig({ devServer: { port: 3456 } });", 'utf-8');
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.framework).toBe('nuxt');
+    expect(result.value.port).toBe(3456);
+  });
+
+  it('detects astro port from astro.config.mjs', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { astro: '^5.0.0' } }), 'utf-8');
+    writeFileSync(join(cwd, 'astro.config.mjs'), "export default { server: { port: 4567 } };", 'utf-8');
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.framework).toBe('astro');
+    expect(result.value.port).toBe(4567);
+  });
+
+  it('uses script port over framework config and env', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'package.json'),
+      JSON.stringify({ devDependencies: { vite: '^7.0.0' }, scripts: { dev: 'vite --port 7777' } }),
+      'utf-8',
+    );
+    writeFileSync(join(cwd, 'vite.config.ts'), 'export default { server: { port: 6123 } };', 'utf-8');
+    writeFileSync(join(cwd, '.env'), 'PORT=9999\n', 'utf-8');
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.port).toBe(7777);
+    expect(result.evidence[0]).toContain('package.json#scripts.dev');
+  });
+
+  it('falls back to framework default when no explicit configuration exists', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { next: '^16.0.0' } }), 'utf-8');
+
+    const result = detectAppTarget(cwd);
+    expect(result.value.framework).toBe('nextjs');
+    expect(result.value.port).toBe(3000);
+  });
+});

--- a/packages/letsrunit/vitest.config.ts
+++ b/packages/letsrunit/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      exclude: [
+        '**/tests/**',
+        'src/index.ts',
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add shared app target detection with precedence: script flags, framework config files, env files, framework defaults
- parse major framework config files (vite, angular, nuxt, astro, vue-cli) for configured ports
- run detection once in init and pass it to both cucumber.js creation and GitHub Actions workflow generation

## Testing
- yarn test --project letsrunit