### PR TITLE
feat: make init component selection explicit

### DIFF
--- a/.github/scripts/init/create-test-project.mjs
+++ b/.github/scripts/init/create-test-project.mjs
@@ -56,8 +56,6 @@ function main() {
     letsrunit: 'file:./letsrunit.tgz',
     '@letsrunit/ai': 'file:./ai.tgz',
     '@letsrunit/bdd': 'file:./bdd.tgz',
-    '@letsrunit/cucumber': 'file:./cucumber.tgz',
-    '@letsrunit/cli': 'file:./cli.tgz',
     '@letsrunit/controller': 'file:./controller.tgz',
     '@letsrunit/executor': 'file:./executor.tgz',
     '@letsrunit/gherker': 'file:./gherker.tgz',
@@ -81,8 +79,12 @@ function main() {
     pkg.packageManager = 'yarn@1.22.22';
     pkg.resolutions = localOverrides;
   } else if (pm === 'pnpm') {
+    pkg.packageManager = 'pnpm@10.22.0';
     pkg.pnpm = { overrides: localOverrides };
   } else if (pm === 'npm' || pm === 'bun') {
+    if (pm === 'bun') {
+      pkg.packageManager = 'bun@1.2.15';
+    }
     pkg.overrides = localOverrides;
   } else {
     throw new Error(`Unsupported package manager: ${pm}`);

--- a/.github/scripts/init/create-test-project.mjs
+++ b/.github/scripts/init/create-test-project.mjs
@@ -74,12 +74,7 @@ function main() {
     version: '1.0.0',
     private: true,
     type: 'module',
-    dependencies: {
-      '@letsrunit/cli': 'file:./cli.tgz',
-      '@letsrunit/cucumber': 'file:./cucumber.tgz',
-      '@cucumber/cucumber': '*',
-      playwright: PLAYWRIGHT_VERSION,
-    },
+    dependencies: {},
   };
 
   if (pm === 'yarn') {

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run init
         working-directory: /tmp/test-${{ matrix.pm }}
-        run: npx -y file:./letsrunit.tgz init --with-cucumber
+        run: npx -y file:./letsrunit.tgz init --with-cli --with-cucumber --with-playwright
 
       - name: Run Cucumber (with web server)
         working-directory: /tmp/test-${{ matrix.pm }}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -87,11 +87,15 @@ jobs:
         with:
           version: latest
 
+      - name: Install native build prerequisites
+        run: |
+          apt-get update
+          apt-get install -y build-essential
+
       - name: Install Bun prerequisites
         if: matrix.pm == 'bun'
         run: |
-          apt-get update
-          apt-get install -y unzip build-essential
+          apt-get install -y unzip
 
       - uses: oven-sh/setup-bun@v2
         if: matrix.pm == 'bun'

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run init
         working-directory: /tmp/test-${{ matrix.pm }}
-        run: npx -y file:./letsrunit.tgz init --yes
+        run: npx -y file:./letsrunit.tgz init --with-cucumber
 
       - name: Run Cucumber (with web server)
         working-directory: /tmp/test-${{ matrix.pm }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,15 +23,14 @@ layout:
 npx letsrunit init
 ```
 
-Run this in your project root. `init` is interactive and sets up what you need.
+Run this in your project root. In an interactive terminal, `init` opens a prompt so you can choose what to set up. In non-interactive environments, pass explicit flags such as `--with-cucumber` or `--with-github-actions`.
 
 #### What `init` sets up
 
 * Letsrunit CLI
 * Cucumber wiring and support files
 * Playwright Chromium browser
-* GitHub Actions workflow (optional)
-* MCP server (optional)
-* AI agent skill (optional)
-
+* GitHub Actions workflow
+* MCP server
+* AI agent skill
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,7 @@ Run this in your project root. In an interactive terminal, `init` opens a prompt
 
 * Letsrunit CLI
 * Cucumber wiring and support files
-* Playwright Chromium browser
+* `@playwright/test` and Playwright Chromium browser
 * GitHub Actions workflow
 * MCP server
 * AI agent skill
-

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -15,19 +15,15 @@ AI Agent integration has two parts:
 
 Install Letsrunit for your project, including the MCP server and skill
 
+```bash
+npx letsrunit init --with-mcp --agents codex
 ```
-npx letsrunit init
-```
-
-The init script will automatically detect all the components to install and configure.
-
-You can also force specific agents:
 
 ```bash
-npx letsrunit init --agents codex,cursor
+npx letsrunit init --with-mcp --agents codex,cursor
 ```
 
-If multiple agents are detected, `init` asks which ones to configure. In non-interactive mode (or with `--yes`), pass `--agents` explicitly to enable agent setup.
+If you run `npx letsrunit init` with no flags in an interactive terminal, the MCP option opens a second prompt where you can choose agents. In non-interactive mode, pass `--agents` explicitly.
 
 ### Global
 

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -6,7 +6,7 @@ description: Run your feature files on every push with GitHub Actions.
 
 The workflow itself is straightforward. The part that requires actual thought is getting your app running inside GitHub Actions so Playwright can reach it.
 
-`npx letsrunit init` scaffolds a workflow file with `npm start` as a starting point. In most cases you'll need to adapt it: the app needs a database, environment variables, a build step, or all of the above. The patterns below cover the most common setups.
+`npx letsrunit init --with-github-actions` scaffolds a workflow file with `npm start` as a starting point. In most cases you'll need to adapt it: the app needs a database, environment variables, a build step, or all of the above. The patterns below cover the most common setups.
 
 ### Base workflow
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ Feature: Example
 {% step %}
 ## Install Playwright browsers
 
-Letsrunit drives a real Chromium browser. Pass `--with-playwright` to install it:
+Letsrunit drives a real Chromium browser. Pass `--with-playwright` to install `@playwright/test` and Chromium:
 
 ```bash
 npx playwright install chromium

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,17 +15,27 @@ description: Set up Letsrunit in your project with a single command.
 npx letsrunit init
 ```
 
-`init` is interactive: it walks you through each step and asks before making changes. It's safe to re-run at any time.
+`init` is safe to re-run at any time.
+
+In an interactive terminal, that command opens a prompt with no preselected components. Choose the pieces you want to install.
+
+In non-interactive environments, pass the components explicitly:
+
+```bash
+npx letsrunit init --with-cli --with-cucumber --with-playwright
+```
 
 For AI agent setup, you can choose explicit agents:
 
 ```bash
-npx letsrunit init --agents codex,cursor
+npx letsrunit init --with-mcp --agents codex,cursor
 ```
 
 Supported values: `codex`, `cursor`, `claude`, `copilot`, `gemini`, `windsurf`.
 
-If `--yes` is used without `--agents`, agent configuration is skipped.
+If you pass `--agents`, `init` configures the selected agent integrations and installs `@letsrunit/mcp-server`.
+
+If you run `npx letsrunit init` without any `--with-*` flags or `--agents` in a non-interactive terminal, it prints help and exits without changing the project.
 
 ### What does the installer do?
 
@@ -33,19 +43,19 @@ If `--yes` is used without `--agents`, agent configuration is skipped.
 {% step %}
 ## Install the CLI
 
-`@letsrunit/cli` is added to your project's dev dependencies. It provides the `letsrunit` binary for `explore`, `generate`, and `run`.
+Pass `--with-cli` to add `@letsrunit/cli` to your project's dev dependencies. It provides the `letsrunit` binary for `explore`, `generate`, and `run`.
 {% endstep %}
 
 {% step %}
 ## Install the MCP server
 
-`@letsrunit/mcp-server` is added to your dev dependencies so AI agents can use a project-local MCP server (and load your project support files safely). You can skip this step with `--no-mcp`.
+Pass `--with-mcp` to add `@letsrunit/mcp-server` to your dev dependencies so AI agents can use a project-local MCP server and load your project support files safely.
 {% endstep %}
 
 {% step %}
 ## Install Cucumber
 
-Letsrunit uses [Cucumber.js](https://cucumber.io/) as the test runner. If it's not already installed, the wizard will offer to add `@cucumber/cucumber` to your dev dependencies.
+Letsrunit uses [Cucumber.js](https://cucumber.io/) as the test runner. Pass `--with-cucumber` to add `@cucumber/cucumber` and scaffold the Letsrunit Cucumber files.
 
 It also creates two files:
 
@@ -83,7 +93,7 @@ Feature: Example
 {% step %}
 ## Install Playwright browsers
 
-Letsrunit drives a real Chromium browser. If Playwright's Chromium binary isn't found, the wizard offers to install it:
+Letsrunit drives a real Chromium browser. Pass `--with-playwright` to install it:
 
 ```bash
 npx playwright install chromium
@@ -93,10 +103,10 @@ npx playwright install chromium
 {% step %}
 ## Add a GitHub Action (optional)
 
-The final step offers to scaffold a `.github/workflows/letsrunit.yml` that runs your features on every push and pull request. See [CI/CD](ci-cd/github-actions.md) for the full workflow.
+Pass `--with-github-actions` to scaffold a `.github/workflows/letsrunit.yml` that runs your features on every push and pull request. See [CI/CD](ci-cd/github-actions.md) for the full workflow.
 {% endstep %}
 {% endstepper %}
 
 {% hint style="info" %}
-Run `npx letsrunit init` again at any time to add steps you skipped the first time.
+Run `npx letsrunit init` again at any time to add more components.
 {% endhint %}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,7 +54,7 @@ program
   .option('--with-cli', 'Install @letsrunit/cli')
   .option('--with-mcp', 'Install @letsrunit/mcp-server')
   .option('--with-cucumber', 'Install @cucumber/cucumber and scaffold Cucumber support')
-  .option('--with-playwright', 'Install Playwright Chromium')
+  .option('--with-playwright', 'Install @playwright/test and Playwright Chromium')
   .option('--with-github-actions', 'Add .github/workflows/letsrunit.yml')
   .option('--agents <list>', `Configure MCP + skill for agents: ${AGENT_IDS.join(', ')}`)
   .action(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { CliSink, Journal } from '@letsrunit/journal';
 import { getMailbox } from '@letsrunit/mailbox';
 import { asFilename, randomUUID } from '@letsrunit/utils';
 import { Command } from 'commander';
-import { init } from 'letsrunit';
+import { formatInitHelp, init, shouldShowInitHelp } from 'letsrunit';
 import { readFileSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -51,12 +51,38 @@ program.name('letsrunit').description('Testing for AI-driven development workflo
 program
   .command('init')
   .description('Set up letsrunit in the current project')
-  .option('-y, --yes', 'Skip confirmation prompts')
-  .option('--no-mcp', 'Do not install @letsrunit/mcp-server')
+  .option('--with-cli', 'Install @letsrunit/cli')
+  .option('--with-mcp', 'Install @letsrunit/mcp-server')
+  .option('--with-cucumber', 'Install @cucumber/cucumber and scaffold Cucumber support')
+  .option('--with-playwright', 'Install Playwright Chromium')
+  .option('--with-github-actions', 'Add .github/workflows/letsrunit.yml')
   .option('--agents <list>', 'Configure MCP + skill for agents (comma-separated)')
-  .action(async (opts: { yes?: boolean; mcp?: boolean; agents?: string }) => {
-    await init({ yes: opts.yes, noMcp: opts.mcp === false, agents: opts.agents });
-  });
+  .action(
+    async (opts: {
+      withCli?: boolean;
+      withMcp?: boolean;
+      withCucumber?: boolean;
+      withPlaywright?: boolean;
+      withGithubActions?: boolean;
+      agents?: string;
+    }) => {
+      const initOptions = {
+        withCli: opts.withCli,
+        withMcp: opts.withMcp,
+        withCucumber: opts.withCucumber,
+        withPlaywright: opts.withPlaywright,
+        withGithubActions: opts.withGithubActions,
+        agents: opts.agents,
+      };
+
+      if (shouldShowInitHelp(Boolean(process.stdout.isTTY && process.stdin.isTTY), initOptions)) {
+        console.log(formatInitHelp());
+        return;
+      }
+
+      await init(initOptions);
+    },
+  );
 
 program
   .command('explore')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { CliSink, Journal } from '@letsrunit/journal';
 import { getMailbox } from '@letsrunit/mailbox';
 import { asFilename, randomUUID } from '@letsrunit/utils';
 import { Command } from 'commander';
-import { formatInitHelp, init, shouldShowInitHelp } from 'letsrunit';
+import { AGENT_IDS, formatInitHelp, init, shouldShowInitHelp } from 'letsrunit';
 import { readFileSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -56,7 +56,7 @@ program
   .option('--with-cucumber', 'Install @cucumber/cucumber and scaffold Cucumber support')
   .option('--with-playwright', 'Install Playwright Chromium')
   .option('--with-github-actions', 'Add .github/workflows/letsrunit.yml')
-  .option('--agents <list>', 'Configure MCP + skill for agents (comma-separated)')
+  .option('--agents <list>', `Configure MCP + skill for agents: ${AGENT_IDS.join(', ')}`)
   .action(
     async (opts: {
       withCli?: boolean;

--- a/packages/letsrunit/README.md
+++ b/packages/letsrunit/README.md
@@ -21,7 +21,7 @@ It can:
 - Install `@cucumber/cucumber` when missing
 - Install `@letsrunit/cucumber` and scaffold Cucumber support
 - Create `features/example.feature` when no feature files exist
-- Install Playwright Chromium when missing
+- Install `@playwright/test` and Playwright Chromium when missing
 - Optionally add `.github/workflows/letsrunit.yml`
 
 ## Options
@@ -36,7 +36,7 @@ It can:
   Install `@cucumber/cucumber` and scaffold Cucumber support.
 
 - `--with-playwright`  
-  Install the Playwright Chromium browser.
+  Install `@playwright/test` and the Playwright Chromium browser.
 
 - `--with-github-actions`  
   Add `.github/workflows/letsrunit.yml`.

--- a/packages/letsrunit/README.md
+++ b/packages/letsrunit/README.md
@@ -12,7 +12,7 @@ npx letsrunit init
 
 ## What `init` does
 
-`init` is interactive by default and safe to rerun.
+`init` is safe to rerun.
 
 It can:
 
@@ -26,15 +26,28 @@ It can:
 
 ## Options
 
-- `-y, --yes`  
-  Skip confirmation prompts and apply defaults.
+- `--with-cli`  
+  Install `@letsrunit/cli`.
 
-- `--no-mcp`  
-  Skip installation of `@letsrunit/mcp-server`.
+- `--with-mcp`  
+  Install `@letsrunit/mcp-server`.
+
+- `--with-cucumber`  
+  Install `@cucumber/cucumber` and scaffold Cucumber support.
+
+- `--with-playwright`  
+  Install the Playwright Chromium browser.
+
+- `--with-github-actions`  
+  Add `.github/workflows/letsrunit.yml`.
 
 - `--agents <list>`  
   Configure MCP + skill for selected agents (comma-separated): `codex,cursor,claude,copilot,gemini,windsurf`.
-  If omitted in non-interactive mode or with `--yes`, agent config is skipped.
+  Passing `--agents` also installs `@letsrunit/mcp-server`.
+
+Run `npx letsrunit init` with no options in an interactive terminal to choose components in a prompt.
+
+In non-interactive mode, running `npx letsrunit init` without any `--with-*` flags or `--agents` prints help and exits.
 
 ## Generated/updated files
 

--- a/packages/letsrunit/src/bin.ts
+++ b/packages/letsrunit/src/bin.ts
@@ -1,20 +1,42 @@
-import { init } from './init.js';
-import { parseAgents } from './setup/agents.js';
+import { formatInitHelp, init, shouldShowInitHelp } from './index.js';
 
 const args = process.argv.slice(2);
-const command = args.find((a) => !a.startsWith('-')) ?? 'init';
-const yes = args.includes('--yes') || args.includes('-y');
-const noMcp = args.includes('--no-mcp');
-const agentsIndex = args.indexOf('--agents');
-const agentsArg = agentsIndex >= 0 ? args[agentsIndex + 1] : undefined;
+const command = args[0] && !args[0].startsWith('-') ? args[0] : 'init';
+const initArgs = command === 'init' && args[0] === 'init' ? args.slice(1) : args;
+
+function hasFlag(flag: string): boolean {
+  return initArgs.includes(flag);
+}
+
+function readOptionValue(name: string): string | undefined {
+  const direct = initArgs.find((arg) => arg.startsWith(`${name}=`));
+  if (direct) return direct.slice(name.length + 1);
+
+  const index = initArgs.indexOf(name);
+  return index >= 0 ? initArgs[index + 1] : undefined;
+}
 
 if (command === 'init') {
-  init({ yes, noMcp, agents: parseAgents(agentsArg) }).catch((err: unknown) => {
+  const initOptions = {
+    withCli: hasFlag('--with-cli'),
+    withMcp: hasFlag('--with-mcp'),
+    withCucumber: hasFlag('--with-cucumber'),
+    withPlaywright: hasFlag('--with-playwright'),
+    withGithubActions: hasFlag('--with-github-actions'),
+    agents: readOptionValue('--agents'),
+  };
+
+  if (hasFlag('--help') || hasFlag('-h') || shouldShowInitHelp(Boolean(process.stdout.isTTY && process.stdin.isTTY), initOptions)) {
+    console.log(formatInitHelp());
+    process.exit(0);
+  }
+
+  init(initOptions).catch((err: unknown) => {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   });
 } else {
   console.error(`Unknown command: ${command}`);
-  console.error('Usage: letsrunit init [--yes] [--no-mcp] [--agents codex,cursor]');
+  console.error(formatInitHelp());
   process.exit(1);
 }

--- a/packages/letsrunit/src/detect.ts
+++ b/packages/letsrunit/src/detect.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export type PackageManager = 'yarn' | 'pnpm' | 'bun' | 'npm';
@@ -22,16 +22,33 @@ export interface PackageManagerArgs {
 export function detectEnvironment(): Environment {
   const cwd = process.cwd();
   const isInteractive = Boolean(process.stdout.isTTY && process.stdin.isTTY);
-
-  let packageManager: PackageManager = 'npm';
-  if (existsSync(join(cwd, 'yarn.lock'))) packageManager = 'yarn';
-  else if (existsSync(join(cwd, 'pnpm-lock.yaml'))) packageManager = 'pnpm';
-  else if (existsSync(join(cwd, 'bun.lockb')) || existsSync(join(cwd, 'bun.lock'))) packageManager = 'bun';
+  const packageManager = detectPackageManager(cwd);
 
   const nodeVersion = parseInt(process.version.slice(1), 10);
   const hasCucumber = existsSync(join(cwd, 'node_modules', '@cucumber', 'cucumber', 'package.json'));
 
   return { isInteractive, packageManager, nodeVersion, hasCucumber, cwd };
+}
+
+export function detectPackageManager(cwd: string): PackageManager {
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(cwd, 'bun.lockb')) || existsSync(join(cwd, 'bun.lock'))) return 'bun';
+
+  const pkgPath = join(cwd, 'package.json');
+  if (!existsSync(pkgPath)) return 'npm';
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { packageManager?: string };
+    const [name] = pkg.packageManager?.split('@') ?? [];
+    if (name === 'yarn' || name === 'pnpm' || name === 'bun' || name === 'npm') {
+      return name;
+    }
+  } catch {
+    return 'npm';
+  }
+
+  return 'npm';
 }
 
 function pmCmd(pm: string, args: PackageManagerArgs): string {

--- a/packages/letsrunit/src/index.ts
+++ b/packages/letsrunit/src/index.ts
@@ -1,2 +1,3 @@
 export { init } from './init.js';
-export type { InitOptions } from './init.js';
+export { formatInitHelp, shouldShowInitHelp } from './init-options.js';
+export type { InitOptions } from './init-options.js';

--- a/packages/letsrunit/src/index.ts
+++ b/packages/letsrunit/src/index.ts
@@ -1,3 +1,4 @@
 export { init } from './init.js';
 export { formatInitHelp, shouldShowInitHelp } from './init-options.js';
+export { AGENT_IDS } from './setup/agents/types.js';
 export type { InitOptions } from './init-options.js';

--- a/packages/letsrunit/src/init-options.ts
+++ b/packages/letsrunit/src/init-options.ts
@@ -1,0 +1,69 @@
+import { AGENT_IDS } from './setup/agents/types.js';
+
+export interface InitOptions {
+  withCli?: boolean;
+  withMcp?: boolean;
+  withCucumber?: boolean;
+  withPlaywright?: boolean;
+  withGithubActions?: boolean;
+  agents?: string | string[];
+}
+
+export interface InitPlanOptions {
+  installCli: boolean;
+  installMcp: boolean;
+  installCucumber: boolean;
+  installPlaywright: boolean;
+  addGithubActions: boolean;
+  configureAgents: boolean;
+}
+
+function hasAgentSelection(agents: InitOptions['agents']): boolean {
+  if (Array.isArray(agents)) return agents.length > 0;
+  return Boolean(agents?.trim());
+}
+
+export function hasExplicitInitSelections(options: InitOptions): boolean {
+  return Boolean(
+    options.withCli ||
+      options.withMcp ||
+      options.withCucumber ||
+      options.withPlaywright ||
+      options.withGithubActions ||
+      hasAgentSelection(options.agents),
+  );
+}
+
+export function shouldShowInitHelp(isInteractive: boolean, options: InitOptions): boolean {
+  return !isInteractive && !hasExplicitInitSelections(options);
+}
+
+export function resolveInitPlanOptions(options: InitOptions): InitPlanOptions {
+  const configureAgents = hasAgentSelection(options.agents);
+  return {
+    installCli: Boolean(options.withCli),
+    installMcp: Boolean(options.withMcp) || configureAgents,
+    installCucumber: Boolean(options.withCucumber),
+    installPlaywright: Boolean(options.withPlaywright),
+    addGithubActions: Boolean(options.withGithubActions),
+    configureAgents,
+  };
+}
+
+export function formatInitHelp(command = 'letsrunit init'): string {
+  return [
+    `Usage: ${command} [options]`,
+    '',
+    'Install nothing by default. Choose components explicitly:',
+    '  --with-cli              Install @letsrunit/cli',
+    '  --with-mcp              Install @letsrunit/mcp-server',
+    '  --with-cucumber         Install @cucumber/cucumber and scaffold Cucumber support',
+    '  --with-playwright       Install Playwright Chromium',
+    '  --with-github-actions   Add .github/workflows/letsrunit.yml',
+    `  --agents <list>         Configure MCP + skill for agents (${AGENT_IDS.join(', ')})`,
+    '  -h, --help              Show this help',
+    '',
+    'Interactive terminals can run `letsrunit init` with no options to choose components in a prompt.',
+    'Non-interactive terminals must pass one or more options explicitly.',
+  ].join('\n');
+}

--- a/packages/letsrunit/src/init-options.ts
+++ b/packages/letsrunit/src/init-options.ts
@@ -64,7 +64,7 @@ export function formatInitHelp(command = 'letsrunit init'): string {
     '  --with-cli              Install @letsrunit/cli',
     '  --with-mcp              Install @letsrunit/mcp-server',
     '  --with-cucumber         Install @cucumber/cucumber and scaffold Cucumber support',
-    '  --with-playwright       Install Playwright Chromium',
+    '  --with-playwright       Install @playwright/test and Playwright Chromium',
     '  --with-github-actions   Add .github/workflows/letsrunit.yml',
     `  --agents <list>         Configure MCP + skill for agents (${AGENT_IDS.join(', ')})`,
     '  -h, --help              Show this help',

--- a/packages/letsrunit/src/init-options.ts
+++ b/packages/letsrunit/src/init-options.ts
@@ -40,12 +40,18 @@ export function shouldShowInitHelp(isInteractive: boolean, options: InitOptions)
 
 export function resolveInitPlanOptions(options: InitOptions): InitPlanOptions {
   const configureAgents = hasAgentSelection(options.agents);
+  const installMcp = Boolean(options.withMcp) || configureAgents;
+  const installCucumber = Boolean(options.withCucumber);
+  const installPlaywright = Boolean(options.withPlaywright);
+  const addGithubActions = Boolean(options.withGithubActions);
+  const installCli = Boolean(options.withCli) || installMcp || installCucumber || installPlaywright || addGithubActions;
+
   return {
-    installCli: Boolean(options.withCli),
-    installMcp: Boolean(options.withMcp) || configureAgents,
-    installCucumber: Boolean(options.withCucumber),
-    installPlaywright: Boolean(options.withPlaywright),
-    addGithubActions: Boolean(options.withGithubActions),
+    installCli,
+    installMcp,
+    installCucumber,
+    installPlaywright,
+    addGithubActions,
     configureAgents,
   };
 }

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -1,6 +1,13 @@
 import { intro, isCancel, log, multiselect, note, outro, spinner } from '@clack/prompts';
 import type { AgentId } from './setup/agents/types.js';
 import { detectEnvironment, type Environment } from './detect.js';
+import {
+  formatInitHelp,
+  hasExplicitInitSelections,
+  type InitOptions,
+  resolveInitPlanOptions,
+  shouldShowInitHelp,
+} from './init-options.js';
 import { installCli, isCliInstalled } from './setup/cli.js';
 import { installCucumber, setupCucumber } from './setup/cucumber.js';
 import { detectAgentIds, getAgentCatalog, parseAgents, setupAgents } from './setup/agents.js';
@@ -27,13 +34,8 @@ const BANNER = String.raw`
      .:::::::::::.           .       .::.       ..:.    ..::.     ..         .:.   ..    .      ..    ..     .::.       
         .::::..                                                                                                         `;
 
-export interface InitOptions {
-  yes?: boolean;
-  noMcp?: boolean;
-  agents?: string | string[];
-}
-
 interface InstallPlan {
+  installCli: boolean;
   installMcp: boolean;
   installCucumber: boolean;
   installPlaywright: boolean;
@@ -125,54 +127,45 @@ function stepAddGithubAction(env: Environment, appTarget: DetectionResult<AppTar
   }
 }
 
-function defaultPlan(env: Environment, options: InitOptions, explicitAgents: AgentId[]): InstallPlan {
-  const installMcp = !options.noMcp;
-  const installCucumber = true;
-  const installPlaywright = true;
-  const addGithubActions = true;
-  const agents = explicitAgents.length > 0 ? explicitAgents : detectAgentIds(env);
-  return { installMcp, installCucumber, installPlaywright, addGithubActions, agents };
+function optionPlan(options: InitOptions, explicitAgents: AgentId[]): InstallPlan {
+  const resolved = resolveInitPlanOptions(options);
+  return {
+    installCli: resolved.installCli,
+    installMcp: resolved.installMcp,
+    installCucumber: resolved.installCucumber,
+    installPlaywright: resolved.installPlaywright,
+    addGithubActions: resolved.addGithubActions,
+    agents: explicitAgents,
+  };
 }
 
-async function selectPlan(env: Environment, options: InitOptions, defaults: InstallPlan): Promise<InstallPlan> {
-  if (options.yes || !env.isInteractive) {
-    if (!options.yes && !env.isInteractive && defaults.installCucumber) {
-      log.warn('@cucumber/cucumber not found. Install it to use letsrunit with Cucumber:');
-      note('npm install --save-dev @cucumber/cucumber\nThen run: npx letsrunit init', 'Setup Cucumber');
-    }
+async function selectPlan(env: Environment, options: InitOptions, detectedAgents: AgentId[]): Promise<InstallPlan | null> {
+  const agentValue = Array.isArray(options.agents) ? options.agents.join(',') : options.agents;
+  const explicitAgents = parseAgents(agentValue);
 
-    if (!options.yes && !env.isInteractive && defaults.installPlaywright) {
-      log.warn('Playwright Chromium browser not found.');
-      note('npx playwright install chromium', 'Run to install browsers');
-    }
+  if (hasExplicitInitSelections(options)) {
+    return optionPlan(options, explicitAgents);
+  }
 
-    return options.yes ? defaults : { ...defaults, installCucumber: false, installPlaywright: false, addGithubActions: false, agents: [] };
+  if (shouldShowInitHelp(env.isInteractive, options)) {
+    console.log(formatInitHelp());
+    return null;
   }
 
   note('Use ↑/↓ to move, space to toggle, enter to continue.', 'Controls');
-  note('`@letsrunit/cli` is always installed and selected.', 'Core Component');
 
   const componentOptions = [
-    { value: 'cucumber', label: 'Cucumber', hint: 'test runner integration', selected: defaults.installCucumber },
-    { value: 'playwright', label: 'Playwright Chromium', hint: 'browser runtime', selected: defaults.installPlaywright },
-    { value: 'gha', label: 'GitHub Actions workflow', hint: 'CI scaffold', selected: defaults.addGithubActions },
+    { value: 'cli', label: 'CLI', hint: '@letsrunit/cli', selected: false },
+    { value: 'mcp', label: 'MCP Server', hint: 'project-local runtime', selected: false },
+    { value: 'cucumber', label: 'Cucumber', hint: 'test runner integration', selected: false },
+    { value: 'playwright', label: 'Playwright Chromium', hint: 'browser runtime', selected: false },
+    { value: 'gha', label: 'GitHub Actions workflow', hint: 'CI scaffold', selected: false },
   ];
-
-  if (!options.noMcp) {
-    componentOptions.unshift({
-      value: 'mcp',
-      label: 'MCP Server',
-      hint: 'project-local runtime',
-      selected: defaults.installMcp,
-    });
-  } else {
-    log.info('MCP Server disabled by --no-mcp.');
-  }
 
   const components = await multiselect({
     message: 'Choose what to install/configure for this project',
     options: componentOptions,
-    initialValues: componentOptions.filter((option) => option.selected).map((option) => option.value),
+    initialValues: [],
     required: false,
   });
 
@@ -181,7 +174,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
   }
 
   const values = new Set((components ?? []) as string[]);
-  const installMcp = options.noMcp ? false : values.has('mcp');
+  const installMcp = values.has('mcp');
 
   let selectedAgents: AgentId[] = [];
   if (installMcp) {
@@ -192,10 +185,10 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
       options: catalog.map((agent) => ({
         value: agent.id,
         label: agent.label,
-        selected: defaults.agents.includes(agent.id),
-        hint: defaults.agents.includes(agent.id) ? 'detected' : undefined,
+        selected: false,
+        hint: detectedAgents.includes(agent.id) ? 'detected' : undefined,
       })),
-      initialValues: defaults.agents,
+      initialValues: [],
       required: false,
     });
 
@@ -209,6 +202,7 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
   }
 
   return {
+    installCli: values.has('cli'),
     installMcp,
     installCucumber: values.has('cucumber'),
     installPlaywright: values.has('playwright'),
@@ -218,21 +212,21 @@ async function selectPlan(env: Environment, options: InitOptions, defaults: Inst
 }
 
 export async function init(options: InitOptions = {}): Promise<void> {
+  const env = detectEnvironment();
+  const detectedAgents = detectAgentIds(env);
+  const plan = await selectPlan(env, options, detectedAgents);
+  if (!plan) return;
+
   intro('letsrunit init');
   showBanner();
 
-  const env = detectEnvironment();
   const appTarget = detectAppTarget(env.cwd);
-  const agentValue = Array.isArray(options.agents) ? options.agents.join(',') : options.agents;
-  const explicitAgents = parseAgents(agentValue);
-  const plan = await selectPlan(env, options, defaultPlan(env, options, explicitAgents));
 
-  await stepInstallCli(env);
+  if (plan.installCli) await stepInstallCli(env);
 
   if (plan.installMcp) stepInstallMcpServer(env);
-  else if (options.noMcp) log.info('Skipped @letsrunit/mcp-server installation (--no-mcp).');
 
-  await setupAgents(env, { agents: plan.agents, noMcp: Boolean(options.noMcp) });
+  await setupAgents(env, { agents: plan.agents });
 
   if (plan.installCucumber) stepInstallCucumber(env);
   if (env.hasCucumber || plan.installCucumber) {

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -43,6 +43,16 @@ interface InstallPlan {
   agents: AgentId[];
 }
 
+function normalizePlan(plan: InstallPlan): InstallPlan {
+  const hasSelectedWork =
+    plan.installCli || plan.installMcp || plan.installCucumber || plan.installPlaywright || plan.addGithubActions || plan.agents.length > 0;
+
+  return {
+    ...plan,
+    installCli: hasSelectedWork,
+  };
+}
+
 function showBanner(): void {
   console.log(BANNER);
 }
@@ -129,14 +139,14 @@ function stepAddGithubAction(env: Environment, appTarget: DetectionResult<AppTar
 
 function optionPlan(options: InitOptions, explicitAgents: AgentId[]): InstallPlan {
   const resolved = resolveInitPlanOptions(options);
-  return {
+  return normalizePlan({
     installCli: resolved.installCli,
     installMcp: resolved.installMcp,
     installCucumber: resolved.installCucumber,
     installPlaywright: resolved.installPlaywright,
     addGithubActions: resolved.addGithubActions,
     agents: explicitAgents,
-  };
+  });
 }
 
 async function selectPlan(env: Environment, options: InitOptions, detectedAgents: AgentId[]): Promise<InstallPlan | null> {
@@ -153,6 +163,7 @@ async function selectPlan(env: Environment, options: InitOptions, detectedAgents
   }
 
   note('Use ↑/↓ to move, space to toggle, enter to continue.', 'Controls');
+  note('`@letsrunit/cli` is installed automatically when you select any component or agent setup.', 'Core Component');
 
   const componentOptions = [
     { value: 'cli', label: 'CLI', hint: '@letsrunit/cli', selected: false },
@@ -201,14 +212,14 @@ async function selectPlan(env: Environment, options: InitOptions, detectedAgents
     log.info('MCP Server not selected. AI agent integration options skipped.');
   }
 
-  return {
+  return normalizePlan({
     installCli: values.has('cli'),
     installMcp,
     installCucumber: values.has('cucumber'),
     installPlaywright: values.has('playwright'),
     addGithubActions: values.has('gha'),
     agents: selectedAgents,
-  };
+  });
 }
 
 export async function init(options: InitOptions = {}): Promise<void> {

--- a/packages/letsrunit/src/init.ts
+++ b/packages/letsrunit/src/init.ts
@@ -15,7 +15,7 @@ import { installGithubAction } from './setup/github-actions.js';
 import { recommendedBaseUrl, updateCucumberBaseUrl } from './setup/ci-workflow-plan.js';
 import { detectAppTarget, type DetectionResult, type AppTarget } from './setup/project-app.js';
 import { installMcpServer, isMcpServerInstalled } from './setup/mcp.js';
-import { hasPlaywrightBrowsers, installPlaywrightBrowsers } from './setup/playwright.js';
+import { hasPlaywrightBrowsers, installPlaywright, installPlaywrightBrowsers, isPlaywrightInstalled } from './setup/playwright.js';
 
 const BDD_IMPORT = '@letsrunit/cucumber';
 
@@ -109,6 +109,15 @@ function stepSetupCucumber(env: Environment, appTarget: DetectionResult<AppTarge
 }
 
 function stepInstallPlaywright(env: Environment): void {
+  if (!isPlaywrightInstalled(env)) {
+    const install = spinner();
+    install.start('Installing @playwright/test…');
+    installPlaywright(env);
+    install.stop('@playwright/test installed');
+  } else {
+    log.success('@playwright/test already installed');
+  }
+
   if (hasPlaywrightBrowsers(env)) {
     log.success('Playwright Chromium already installed');
     return;

--- a/packages/letsrunit/src/setup/agents.ts
+++ b/packages/letsrunit/src/setup/agents.ts
@@ -44,13 +44,8 @@ function resolveStrategies(ids: AgentId[]): AgentStrategy[] {
 
 export async function setupAgents(
   env: Pick<Environment, 'cwd'>,
-  options: { agents?: AgentId[]; noMcp?: boolean },
+  options: { agents?: AgentId[] },
 ): Promise<void> {
-  if (options.noMcp) {
-    log.info('Skipped AI agent setup because MCP installation is disabled (--no-mcp).');
-    return;
-  }
-
   const agentIds = options.agents ?? [];
   if (agentIds.length === 0) {
     log.info('Skipped AI agent setup.');

--- a/packages/letsrunit/src/setup/cli.ts
+++ b/packages/letsrunit/src/setup/cli.ts
@@ -18,7 +18,7 @@ export function installCli(env: Pick<Environment, 'packageManager' | 'cwd'>): vo
   execPm(env, {
     npm: 'install --save-dev @letsrunit/cli',
     yarn: 'add --dev @letsrunit/cli',
-    pnpm: 'add -D @letsrunit/cli',
+    pnpm: '--allow-build=re2 add -D @letsrunit/cli',
     bun: 'add -d @letsrunit/cli',
   });
 }

--- a/packages/letsrunit/src/setup/cli.ts
+++ b/packages/letsrunit/src/setup/cli.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type Environment, execPm } from '../detect.js';
+import { resolveInstallSpec } from './local-package.js';
 
 export function isCliInstalled({ cwd }: Pick<Environment, 'cwd'>): boolean {
   const pkgPath = join(cwd, 'package.json');
@@ -15,10 +16,11 @@ export function isCliInstalled({ cwd }: Pick<Environment, 'cwd'>): boolean {
 }
 
 export function installCli(env: Pick<Environment, 'packageManager' | 'cwd'>): void {
+  const spec = resolveInstallSpec(env, '@letsrunit/cli', 'cli.tgz');
   execPm(env, {
-    npm: 'install --save-dev @letsrunit/cli',
-    yarn: 'add --dev @letsrunit/cli',
-    pnpm: '--allow-build=re2 add -D @letsrunit/cli',
-    bun: 'add -d @letsrunit/cli',
+    npm: `install --save-dev ${spec}`,
+    yarn: `add --dev ${spec}`,
+    pnpm: `--allow-build=re2 add -D ${spec}`,
+    bun: `add -d ${spec}`,
   });
 }

--- a/packages/letsrunit/src/setup/cucumber.ts
+++ b/packages/letsrunit/src/setup/cucumber.ts
@@ -83,7 +83,7 @@ function installBdd(env: Pick<Environment, 'packageManager' | 'cwd'>): boolean {
   execPm(env, {
     npm: 'install --save-dev @letsrunit/cucumber',
     yarn: 'add --dev @letsrunit/cucumber',
-    pnpm: 'add -D @letsrunit/cucumber',
+    pnpm: '--allow-build=re2 add -D @letsrunit/cucumber',
     bun: 'add -d @letsrunit/cucumber',
   });
 

--- a/packages/letsrunit/src/setup/cucumber.ts
+++ b/packages/letsrunit/src/setup/cucumber.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type Environment, execPm } from '../detect.js';
+import { resolveInstallSpec } from './local-package.js';
 
 const BDD_IMPORT = '@letsrunit/cucumber';
 
@@ -80,11 +81,13 @@ function installBdd(env: Pick<Environment, 'packageManager' | 'cwd'>): boolean {
 
   if (alreadyInstalled) return false;
 
+  const spec = resolveInstallSpec(env, '@letsrunit/cucumber', 'cucumber.tgz');
+
   execPm(env, {
-    npm: 'install --save-dev @letsrunit/cucumber',
-    yarn: 'add --dev @letsrunit/cucumber',
-    pnpm: '--allow-build=re2 add -D @letsrunit/cucumber',
-    bun: 'add -d @letsrunit/cucumber',
+    npm: `install --save-dev ${spec}`,
+    yarn: `add --dev ${spec}`,
+    pnpm: `--allow-build=re2 add -D ${spec}`,
+    bun: `add -d ${spec}`,
   });
 
   return true;

--- a/packages/letsrunit/src/setup/local-package.ts
+++ b/packages/letsrunit/src/setup/local-package.ts
@@ -1,0 +1,16 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Environment } from '../detect.js';
+
+export function resolveInstallSpec(
+  env: Pick<Environment, 'cwd'>,
+  packageName: string,
+  tarballName: string,
+): string {
+  const tarballPath = join(env.cwd, tarballName);
+  if (existsSync(tarballPath)) {
+    return `file:./${tarballName}`;
+  }
+
+  return packageName;
+}

--- a/packages/letsrunit/src/setup/mcp.ts
+++ b/packages/letsrunit/src/setup/mcp.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type Environment, execPm } from '../detect.js';
+import { resolveInstallSpec } from './local-package.js';
 
 export function isMcpServerInstalled({ cwd }: Pick<Environment, 'cwd'>): boolean {
   const pkgPath = join(cwd, 'package.json');
@@ -18,10 +19,11 @@ export function isMcpServerInstalled({ cwd }: Pick<Environment, 'cwd'>): boolean
 }
 
 export function installMcpServer(env: Pick<Environment, 'packageManager' | 'cwd'>): void {
+  const spec = resolveInstallSpec(env, '@letsrunit/mcp-server', 'mcp-server.tgz');
   execPm(env, {
-    npm: 'install --save-dev @letsrunit/mcp-server',
-    yarn: 'add --dev @letsrunit/mcp-server',
-    pnpm: 'add -D @letsrunit/mcp-server',
-    bun: 'add -d @letsrunit/mcp-server',
+    npm: `install --save-dev ${spec}`,
+    yarn: `add --dev ${spec}`,
+    pnpm: `add -D ${spec}`,
+    bun: `add -d ${spec}`,
   });
 }

--- a/packages/letsrunit/src/setup/playwright.ts
+++ b/packages/letsrunit/src/setup/playwright.ts
@@ -1,7 +1,21 @@
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type Environment, execPm } from '../detect.js';
+
+const PLAYWRIGHT_TEST_VERSION = '1.58.2';
+
+export function isPlaywrightInstalled({ cwd }: Pick<Environment, 'cwd'>): boolean {
+  const pkgPath = join(cwd, 'package.json');
+  if (!existsSync(pkgPath)) return false;
+
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+    devDependencies?: Record<string, string>;
+    dependencies?: Record<string, string>;
+  };
+
+  return '@playwright/test' in (pkg.devDependencies ?? {}) || '@playwright/test' in (pkg.dependencies ?? {});
+}
 
 export function hasPlaywrightBrowsers({ cwd }: Pick<Environment, 'cwd'>): boolean {
   if (!existsSync(join(cwd, 'node_modules', 'playwright-core', 'package.json'))) {
@@ -16,6 +30,17 @@ export function hasPlaywrightBrowsers({ cwd }: Pick<Environment, 'cwd'>): boolea
   } catch {
     return false;
   }
+}
+
+export function installPlaywright(env: Pick<Environment, 'packageManager' | 'cwd'>): void {
+  const spec = `@playwright/test@${PLAYWRIGHT_TEST_VERSION}`;
+
+  execPm(env, {
+    npm: `install --save-dev ${spec}`,
+    yarn: `add --dev ${spec}`,
+    pnpm: `add -D ${spec}`,
+    bun: `add -d ${spec}`,
+  });
 }
 
 export function installPlaywrightBrowsers(env: Pick<Environment, 'packageManager' | 'cwd'>): void {

--- a/packages/letsrunit/tests/agents.test.ts
+++ b/packages/letsrunit/tests/agents.test.ts
@@ -74,7 +74,7 @@ describe('setupAgents behavior', () => {
     mkdirSync(join(cwd, 'agent', 'skills', 'letsrunit'), { recursive: true });
     writeFileSync(join(cwd, 'agent', 'skills', 'letsrunit', 'SKILL.md'), 'demo', 'utf-8');
 
-    await setupAgents({ cwd, isInteractive: false }, { yes: false, noMcp: false, agents: [] });
+    await setupAgents({ cwd, isInteractive: false }, { agents: [] });
 
     expect(() => readFileSync(join(cwd, '.mcp.json'), 'utf-8')).toThrow();
   });
@@ -84,7 +84,7 @@ describe('setupAgents behavior', () => {
     mkdirSync(join(cwd, 'agent', 'skills', 'letsrunit'), { recursive: true });
     writeFileSync(join(cwd, 'agent', 'skills', 'letsrunit', 'SKILL.md'), 'demo', 'utf-8');
 
-    await setupAgents({ cwd, isInteractive: false }, { yes: true, noMcp: false, agents: ['cursor'] });
+    await setupAgents({ cwd, isInteractive: false }, { agents: ['cursor'] });
 
     const configPath = join(cwd, '.cursor', 'mcp.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {

--- a/packages/letsrunit/tests/detect.test.ts
+++ b/packages/letsrunit/tests/detect.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectPackageManager } from '../src/detect.js';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'letsrunit-detect-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe('detectPackageManager', () => {
+  it('prefers lockfiles when present', () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'npm@10.0.0' }));
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), '');
+
+    expect(detectPackageManager(dir)).toBe('pnpm');
+  });
+
+  it('falls back to packageManager metadata when no lockfile exists', () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'bun@1.2.15' }));
+
+    expect(detectPackageManager(dir)).toBe('bun');
+  });
+
+  it('defaults to npm when packageManager metadata is missing or invalid', () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ packageManager: 'unknown@1.0.0' }));
+
+    expect(detectPackageManager(dir)).toBe('npm');
+  });
+});

--- a/packages/letsrunit/tests/init-options.test.ts
+++ b/packages/letsrunit/tests/init-options.test.ts
@@ -16,12 +16,32 @@ describe('init option selection', () => {
 
   it('treats agent setup as an mcp install request', () => {
     expect(resolveInitPlanOptions({ agents: 'codex,cursor' })).toEqual({
-      installCli: false,
+      installCli: true,
       installMcp: true,
       installCucumber: false,
       installPlaywright: false,
       addGithubActions: false,
       configureAgents: true,
+    });
+  });
+
+  it('treats component selections as a cli install request', () => {
+    expect(resolveInitPlanOptions({ withCucumber: true })).toEqual({
+      installCli: true,
+      installMcp: false,
+      installCucumber: true,
+      installPlaywright: false,
+      addGithubActions: false,
+      configureAgents: false,
+    });
+
+    expect(resolveInitPlanOptions({ withGithubActions: true })).toEqual({
+      installCli: true,
+      installMcp: false,
+      installCucumber: false,
+      installPlaywright: false,
+      addGithubActions: true,
+      configureAgents: false,
     });
   });
 

--- a/packages/letsrunit/tests/init-options.test.ts
+++ b/packages/letsrunit/tests/init-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { formatInitHelp, hasExplicitInitSelections, resolveInitPlanOptions, shouldShowInitHelp } from '../src/init-options.js';
+
+describe('init option selection', () => {
+  it('requires explicit selections in non-interactive mode', () => {
+    expect(shouldShowInitHelp(false, {})).toBe(true);
+    expect(shouldShowInitHelp(false, { withCli: true })).toBe(false);
+    expect(shouldShowInitHelp(false, { agents: 'codex' })).toBe(false);
+  });
+
+  it('detects explicit init selections', () => {
+    expect(hasExplicitInitSelections({})).toBe(false);
+    expect(hasExplicitInitSelections({ withPlaywright: true })).toBe(true);
+    expect(hasExplicitInitSelections({ agents: ['cursor'] })).toBe(true);
+  });
+
+  it('treats agent setup as an mcp install request', () => {
+    expect(resolveInitPlanOptions({ agents: 'codex,cursor' })).toEqual({
+      installCli: false,
+      installMcp: true,
+      installCucumber: false,
+      installPlaywright: false,
+      addGithubActions: false,
+      configureAgents: true,
+    });
+  });
+
+  it('formats help with the explicit component flags', () => {
+    const help = formatInitHelp();
+    expect(help).toContain('--with-cli');
+    expect(help).toContain('--with-mcp');
+    expect(help).toContain('--with-cucumber');
+    expect(help).toContain('--with-playwright');
+    expect(help).toContain('--with-github-actions');
+    expect(help).toContain('--agents <list>');
+  });
+});


### PR DESCRIPTION
## Type

Feature

## Summary

Make `letsrunit init` opt-in by component so non-interactive runs do not make implicit changes, and make the available agent values visible in `init --help`.

## Changes

- replace the old default-install / `--no-mcp` flow with explicit `--with-*` flags for CLI, MCP, Cucumber, Playwright, and GitHub Actions
- make non-interactive `init` with no selections print help and exit without changing the project
- skip the interactive prompt whenever `--with-*` flags or `--agents` are provided
- update both `letsrunit` entrypoints and installer documentation to match the new flag model
- include the supported agent IDs directly in the Commander `init --help` output
