### PR TITLE
feat: add BDD assertions and fix fallback field setting

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,0 @@
-[mcp_servers.letsrunit]
-command = "node_modules/.bin/tsx"
-args = ["packages/mcp-server/src/index.ts"]
-
-[mcp_servers.letsrunit.env]
-LETSRUNIT_MCP_RUNTIME_MODE = "standalone"

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ next-env.d.ts
 .env*.local
 .playwright-mcp/
 .claude
+.codex/
 
 # Build outputs
 dist/

--- a/compat/react/tests/primereact/fuzzy-field.spec.tsx
+++ b/compat/react/tests/primereact/fuzzy-field.spec.tsx
@@ -1,0 +1,13 @@
+import { setFieldValue } from '@letsrunit/playwright';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { createFallbackLocator } from '../../../../packages/playwright/src/fallback-locator';
+import { PrimeReactInputText } from '../../src/primereact/inputs';
+
+test('PrimeReact InputText via fallback locator', async ({ mount, page }) => {
+  await mount(<PrimeReactInputText />);
+
+  const locator = createFallbackLocator([page.locator('#missing-field'), page.getByLabel('Text')]);
+  await setFieldValue(locator, 'hello', { timeout: 1000 });
+
+  await expect(page.getByLabel('Text')).toHaveValue('hello');
+});

--- a/docs/writing-tests/step-reference.md
+++ b/docs/writing-tests/step-reference.md
@@ -22,12 +22,19 @@ Given I'm on page "/login"
 | Step                                                      | Description |
 |-----------------------------------------------------------|-------------|
 | `Then the page {contains\|does not contain} {selector}`   | Assert an element is (or is not) visible |
+| `Then {selector} is {visible\|hidden}`                    | Assert a specific element is visible or hidden |
 | `Then {selector} {contains\|does not contain} {selector}` | Assert a child element is (or is not) inside a parent |
+| `Then {selector} has focus`                               | Assert an element has focus |
+| `Then {selector} does not have focus`                     | Assert an element does not have focus |
 | `Then I should be on page {url}`                          | Assert the current path (supports `:param` wildcards) |
 
 ```gherkin
 Then The page contains text "Welcome"
 Then The page does not contain button "Sign in"
+Then button "Save" is visible
+Then text "Loading" is hidden
+Then field "Email" has focus
+Then button "Submit" does not have focus
 Then I should be on page "/dashboard"
 Then I should be on page "/users/:id/profile"
 ```
@@ -119,4 +126,3 @@ See [Email Testing](email-testing.md) for setup and examples.
 ## Custom steps
 
 You can add your <a href="custom-steps">own step definitions</a> for project-specific behavior.
-

--- a/packages/bdd/src/steps/assert.ts
+++ b/packages/bdd/src/steps/assert.ts
@@ -12,11 +12,35 @@ export const see = Then(
   },
 );
 
+export const visible = Then(
+  '{locator} is {visible|hidden}',
+  async function (selector: string, visible: boolean) {
+    const el = await fuzzyLocator(this.page, selector);
+    await expectOrNot(el, visible).toBeVisible({ timeout: WAIT_TIMEOUT });
+  },
+);
+
 export const contain = Then(
   '{locator} {contains|does not contain} {locator}',
   async function (selector: string, contain: boolean, child: string) {
     const el = await fuzzyLocator(this.page, selector);
     const childElement = el.locator(child);
     await expectOrNot(childElement, contain).toBeAttached({ timeout: WAIT_TIMEOUT });
+  },
+);
+
+export const focused = Then(
+  '{locator} has focus',
+  async function (selector: string) {
+    const el = await fuzzyLocator(this.page, selector);
+    await expectOrNot(el, true).toBeFocused({ timeout: WAIT_TIMEOUT });
+  },
+);
+
+export const notFocused = Then(
+  '{locator} does not have focus',
+  async function (selector: string) {
+    const el = await fuzzyLocator(this.page, selector);
+    await expectOrNot(el, false).toBeFocused({ timeout: WAIT_TIMEOUT });
   },
 );

--- a/packages/bdd/tests/steps/assert.test.ts
+++ b/packages/bdd/tests/steps/assert.test.ts
@@ -1,6 +1,6 @@
 import { fuzzyLocator as resolveLocator } from '@letsrunit/playwright';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { contain, see } from '../../src/steps/assert';
+import { contain, focused, notFocused, see, visible } from '../../src/steps/assert';
 import { expectOrNot } from '../../src/utils/test-helpers';
 import { runStep } from '../helpers';
 
@@ -13,6 +13,7 @@ vi.mock('@letsrunit/playwright', () => ({
 
 const toBeVisible = vi.fn();
 const toBeAttached = vi.fn();
+const toBeFocused = vi.fn();
 
 vi.mock('../../src/utils/test-helpers', () => {
   return {
@@ -20,6 +21,7 @@ vi.mock('../../src/utils/test-helpers', () => {
       return {
         toBeVisible: (...args: any[]) => toBeVisible(...args),
         toBeAttached: (...args: any[]) => toBeAttached(...args),
+        toBeFocused: (...args: any[]) => toBeFocused(...args),
       };
     }),
     __esModule: true,
@@ -51,6 +53,20 @@ describe('steps/assert (definitions)', () => {
     expect(expectOrNot).toHaveBeenLastCalledWith(elementLocatorMock, false);
   });
 
+  it('asserts a locator is visible or hidden with timeout 5000', async () => {
+    const page = {} as any;
+
+    await runStep(visible, '`#thing` is visible', { page } as any);
+    expect(resolveLocator).toHaveBeenLastCalledWith(page, '#thing');
+    expect(toBeVisible).toHaveBeenLastCalledWith({ timeout: 5000 });
+    expect(expectOrNot).toHaveBeenLastCalledWith(elementLocatorMock, true);
+
+    await runStep(visible, '`.item` is hidden', { page } as any);
+    expect(resolveLocator).toHaveBeenLastCalledWith(page, '.item');
+    expect(toBeVisible).toHaveBeenLastCalledWith({ timeout: 5000 });
+    expect(expectOrNot).toHaveBeenLastCalledWith(elementLocatorMock, false);
+  });
+
   it('waits for child attachment or detachment with timeout 5000', async () => {
     const page = {} as any;
 
@@ -65,5 +81,19 @@ describe('steps/assert (definitions)', () => {
     expect(parentLocatorMock.locator).toHaveBeenLastCalledWith('.card');
     expect(toBeAttached).toHaveBeenLastCalledWith({ timeout: 5000 });
     expect(expectOrNot).toHaveBeenLastCalledWith(childLocatorMock, false);
+  });
+
+  it('asserts whether a locator has focus with timeout 5000', async () => {
+    const page = {} as any;
+
+    await runStep(focused, '`#thing` has focus', { page } as any);
+    expect(resolveLocator).toHaveBeenLastCalledWith(page, '#thing');
+    expect(toBeFocused).toHaveBeenLastCalledWith({ timeout: 5000 });
+    expect(expectOrNot).toHaveBeenLastCalledWith(elementLocatorMock, true);
+
+    await runStep(notFocused, '`.item` does not have focus', { page } as any);
+    expect(resolveLocator).toHaveBeenLastCalledWith(page, '.item');
+    expect(toBeFocused).toHaveBeenLastCalledWith({ timeout: 5000 });
+    expect(expectOrNot).toHaveBeenLastCalledWith(elementLocatorMock, false);
   });
 });

--- a/packages/playwright/src/fallback-locator.ts
+++ b/packages/playwright/src/fallback-locator.ts
@@ -2,6 +2,7 @@ import { Locator } from '@playwright/test';
 
 type LocatorMethod = (...args: any[]) => any;
 type ProxyProperty = string | symbol;
+export const FALLBACK_LOCATOR_CANDIDATES = Symbol('letsrunit.playwright.fallback-locator-candidates');
 
 const ACTION_METHODS = new Set([
   'blur',
@@ -158,6 +159,7 @@ export function createFallbackLocator(candidates: Locator[]): Locator {
 
   const proxy = new Proxy(primary as unknown as object, {
     get(_target, prop: ProxyProperty) {
+      if (prop === FALLBACK_LOCATOR_CANDIDATES) return candidates;
       if (typeof prop !== 'string') return (primary as any)[prop];
       if (passthroughMetaProperties.has(prop)) return (primary as any)[prop];
 
@@ -194,4 +196,8 @@ export function createFallbackLocator(candidates: Locator[]): Locator {
   });
 
   return proxy as Locator;
+}
+
+export function getFallbackLocatorCandidates(locator: Locator): Locator[] | null {
+  return ((locator as any)[FALLBACK_LOCATOR_CANDIDATES] as Locator[] | undefined) ?? null;
 }

--- a/packages/playwright/src/field/index.ts
+++ b/packages/playwright/src/field/index.ts
@@ -55,9 +55,7 @@ export async function setFieldValue(el: Locator, value: Value, options?: SetOpti
     setFallback,
   );
 
-  if ((await el.count()) > 1) {
-    el = await pickFieldElement(el);
-  }
+  el = await pickFieldElement(el);
 
   const tag = await el.evaluate((e) => e.tagName.toLowerCase(), options);
   const type = (

--- a/packages/playwright/src/utils/pick-field-element.ts
+++ b/packages/playwright/src/utils/pick-field-element.ts
@@ -1,8 +1,24 @@
 import type { Locator } from '@playwright/test';
+import { getFallbackLocatorCandidates } from '../fallback-locator';
+
+async function resolveConcreteFieldLocator(elements: Locator): Promise<Locator> {
+  const fallbackCandidates = getFallbackLocatorCandidates(elements);
+  if (!fallbackCandidates) return elements;
+
+  for (const candidate of fallbackCandidates) {
+    try {
+      if ((await candidate.count()) > 0) return candidate;
+    } catch {}
+  }
+
+  return elements;
+}
 
 export async function pickFieldElement(elements: Locator): Promise<Locator> {
+  elements = await resolveConcreteFieldLocator(elements);
+
   const count = await elements.count();
-  if (count === 1) return elements;
+  if (count <= 1) return elements.first();
 
   const candidates: { el: Locator; tag: string; role: string | null; isVisible: boolean }[] = [];
 
@@ -43,6 +59,5 @@ export async function pickFieldElement(elements: Locator): Promise<Locator> {
     return elements.nth(isParent);
   }
 
-  // Return both elements and let the error (on evaluate) occur.
-  return elements;
+  return elements.first();
 }

--- a/packages/playwright/tests/field/index.test.ts
+++ b/packages/playwright/tests/field/index.test.ts
@@ -1,5 +1,6 @@
 import type { Locator } from '@playwright/test';
 import { describe, expect, it, vi } from 'vitest';
+import { createFallbackLocator } from '../../src/fallback-locator';
 import { setFieldValue } from '../../src/field/index';
 
 function makeEmptyLocator() {
@@ -28,6 +29,7 @@ function makeMockEl(tag: string, type: string | null): Locator {
   const emptyLoc = makeEmptyLocator();
   const el: any = {
     count: vi.fn().mockResolvedValue(1),
+    first: vi.fn().mockReturnThis(),
     evaluate: vi.fn().mockResolvedValue(tag),
     getAttribute: vi.fn().mockImplementation(async (attr: string) => {
       if (attr === 'type') return type;
@@ -67,5 +69,17 @@ describe('setFieldValue', () => {
     const el = makeMockEl('div', null);
     await setFieldValue(el, { from: 1, to: 5 });
     expect((el as any).fill).toHaveBeenCalledWith('1 - 5', undefined);
+  });
+
+  it('normalizes a fallback locator before handler probing', async () => {
+    const missingPrimary = makeMockEl('div', null);
+    (missingPrimary as any).count = vi.fn().mockResolvedValue(0);
+
+    const input = makeMockEl('input', 'text');
+    const locator = createFallbackLocator([missingPrimary, input]);
+
+    await setFieldValue(locator, 'hello');
+
+    expect((input as any).fill).toHaveBeenCalledWith('hello', undefined);
   });
 });

--- a/packages/playwright/tests/utils/pick-field-element.test.ts
+++ b/packages/playwright/tests/utils/pick-field-element.test.ts
@@ -1,18 +1,26 @@
 import type { Locator } from '@playwright/test';
 import { describe, expect, it, vi } from 'vitest';
+import { createFallbackLocator } from '../../src/fallback-locator';
 import { pickFieldElement } from '../../src/utils/pick-field-element';
 
 describe('pickFieldElement', () => {
   const createMockLocator = (elements: any[]) => {
+    const singleLocatorFor = (el: any) =>
+      ({
+        count: vi.fn(async () => 1),
+        first: vi.fn().mockReturnThis(),
+        nth: vi.fn().mockReturnThis(),
+        evaluate: vi.fn(async (fn: any) => fn(el)),
+        getAttribute: vi.fn(async (name: string) => el.getAttribute(name)),
+        fill: vi.fn(async () => {}),
+      }) as unknown as Locator;
+
     return {
       count: vi.fn(async () => elements.length),
+      first: vi.fn(() => singleLocatorFor(elements[0])),
       nth: vi.fn((index) => {
         const el = elements[index];
-        return {
-          evaluate: vi.fn(async (fn: any) => fn(el)),
-          getAttribute: vi.fn(async (name: string) => el.getAttribute(name)),
-          fill: vi.fn(async () => {}),
-        } as unknown as Locator;
+        return singleLocatorFor(el);
       }),
       evaluateAll: vi.fn(async (fn: any) => fn(elements)),
       evaluate: vi.fn(async (fn: any) => {
@@ -49,9 +57,8 @@ describe('pickFieldElement', () => {
 
     const multiLocator = createMockLocator([inputMock, divMock]);
 
-    // Should pick inputMock because offset doesn't matter anymore, only type/aria-hidden
     const result = await pickFieldElement(multiLocator);
-    await result.evaluate(() => {});
+    expect(await result.evaluate((node) => node.tagName)).toBe('INPUT');
   });
 
   it('picks role="group" when no primary controls are found', async () => {
@@ -72,7 +79,7 @@ describe('pickFieldElement', () => {
 
     const multiLocator = createMockLocator([groupMock, divMock]);
     const result = await pickFieldElement(multiLocator);
-    await result.evaluate(() => {});
+    expect(await result.evaluate((node) => node.getAttribute('role'))).toBe('group');
   });
 
   it('picks the parent element when one contains others', async () => {
@@ -94,12 +101,11 @@ describe('pickFieldElement', () => {
     };
 
     const multiLocator = createMockLocator([childMock, parentMock]);
-    // It should pick parent because child is aria-hidden and parent contains child
     const result = await pickFieldElement(multiLocator);
-    await result.evaluate(() => {});
+    expect(await result.evaluate((node) => node.tagName)).toBe('DIV');
   });
 
-  it('fails with multiple elements if no rule matches', async () => {
+  it('falls back to the first element if no rule matches', async () => {
     const div1 = {
       tagName: 'DIV',
       getAttribute: () => null,
@@ -119,9 +125,7 @@ describe('pickFieldElement', () => {
 
     const multiLocator = createMockLocator([div1, div2]);
     const result = await pickFieldElement(multiLocator);
-    await expect(result.evaluate(() => {})).rejects.toThrow(
-      'strict mode violation: locator resolved to 2 elements',
-    );
+    expect(await result.evaluate((node) => node.tagName)).toBe('DIV');
   });
 
   it('excludes input[type=hidden] from primary candidates', async () => {
@@ -141,9 +145,8 @@ describe('pickFieldElement', () => {
     };
 
     const multiLocator = createMockLocator([hiddenInputMock, visibleInputMock]);
-    // Should pick visibleInputMock because hiddenInputMock is type="hidden"
     const result = await pickFieldElement(multiLocator);
-    await result.evaluate(() => {});
+    expect(await result.evaluate((node) => node.getAttribute('type'))).toBe('text');
   });
 
   it('excludes elements with aria-hidden="true" from primary candidates', async () => {
@@ -163,8 +166,22 @@ describe('pickFieldElement', () => {
     };
 
     const multiLocator = createMockLocator([ariaHiddenInputMock, visibleInputMock]);
-    // Should pick visibleInputMock because ariaHiddenInputMock has aria-hidden="true"
     const result = await pickFieldElement(multiLocator);
-    await result.evaluate(() => {});
+    expect(await result.evaluate((node) => node.getAttribute('aria-hidden'))).toBeNull();
+  });
+
+  it('resolves a fallback locator to the first present concrete candidate', async () => {
+    const missingPrimary = createMockLocator([]);
+    const presentFallback = createMockLocator([
+      {
+        tagName: 'INPUT',
+        getAttribute: (name: string) => (name === 'type' ? 'text' : null),
+      },
+    ]);
+
+    const locator = createFallbackLocator([missingPrimary as unknown as Locator, presentFallback as unknown as Locator]);
+    const result = await pickFieldElement(locator);
+
+    expect(await result.evaluate((node) => node.tagName)).toBe('INPUT');
   });
 });


### PR DESCRIPTION
## Type

Feature

## Summary

Improve BDD test authoring by adding visibility and focus assertions, and fix field setting through fuzzy locators so labeled inputs work reliably in real apps.

## Changes

- add BDD assertions for visibility and focus, with matching docs and step tests
- normalize fallback locators to concrete field locators before running field handlers
- add Playwright and PrimeReact regressions for fallback-backed field setting
- ignore local `.codex/` workspace files and stop tracking the existing config file
