### PR TITLE
[codex] Fix MCP setup and dependabot automerge workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,30 +21,30 @@ jobs:
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const prs = context.payload.workflow_run.pull_requests;
-          if (!prs?.length) {
-            core.setFailed('No pull request found for workflow_run');
-            return;
-          }
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs?.length) {
+              core.setFailed('No pull request found for workflow_run');
+              return;
+            }
 
-          const pull_number = prs[0].number;
+            const pull_number = prs[0].number;
 
-          const pr = await github.rest.pulls.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number,
-          });
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
 
-          if (pr.data.user.login !== 'dependabot[bot]') {
-            core.info(`Skipped: PR author is ${pr.data.user.login}`);
-            return;
-          }
+            if (pr.data.user.login !== 'dependabot[bot]') {
+              core.info(`Skipped: PR author is ${pr.data.user.login}`);
+              return;
+            }
 
-          await github.rest.pulls.merge({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number,
-          });
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
 
-          core.info('Merged');
+            core.info('Merged');

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -37,13 +37,10 @@ The Letsrunit plugin installs both the MCP server and the skill automatically. R
 {% endtab %}
 
 {% tab title="Codex CLI" %}
-Add the MCP server to `~/.codex/config.toml`:
+Add the MCP server:
 
-```toml
-[[mcp_servers]]
-name = "letsrunit"
-command = "npx"
-args = ["-y", "@letsrunit/mcp-server@latest"]
+```bash
+codex mcp add letsrunit -- npx -y @letsrunit/mcp-server@latest
 ```
 
 Install the skill into your repo.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ npx letsrunit init --agents codex,cursor
 
 Supported values: `codex`, `cursor`, `claude`, `copilot`, `gemini`, `windsurf`.
 
-If you pass `--agents`, `init` configures the selected agent integrations and installs `@letsrunit/mcp-server`.
+If you pass `--agents`, `init` configures the selected agent integrations in your project and installs `@letsrunit/mcp-server`.
 
 If you run `npx letsrunit init` without any `--with-*` flags or `--agents` in a non-interactive terminal, it prints help and exits without changing the project.
 

--- a/packages/bdd/package.json
+++ b/packages/bdd/package.json
@@ -49,14 +49,15 @@
     "@letsrunit/mailbox": "workspace:*",
     "@letsrunit/playwright": "workspace:*",
     "@letsrunit/utils": "workspace:*",
-    "@playwright/test": "1.58.2",
     "iso-639-1": "^3.1.5"
   },
   "peerDependencies": {
-    "@cucumber/cucumber": "^12.0.0"
+    "@cucumber/cucumber": "^12.0.0",
+    "@playwright/test": "^1.58.2"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^12.7.0"
+    "@cucumber/cucumber": "^12.7.0",
+    "@playwright/test": "1.58.2"
   },
   "module": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -56,9 +56,9 @@
     "@playwright/test": "^1.58.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.58.2",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^25.0.9",
-    "@playwright/test": "1.58.2",
     "typescript": "^5.9.3"
   },
   "module": "./src/index.ts",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -49,13 +49,16 @@
     "@letsrunit/journal": "workspace:*",
     "@letsrunit/playwright": "workspace:*",
     "@letsrunit/utils": "workspace:*",
-    "@playwright/test": "1.58.2",
     "jsdom": "^27.4.0",
     "zod": "^4.3.5"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.58.2"
   },
   "devDependencies": {
     "@types/jsdom": "^27.0.0",
     "@types/node": "^25.0.9",
+    "@playwright/test": "1.58.2",
     "typescript": "^5.9.3"
   },
   "module": "./src/index.ts",

--- a/packages/cucumber/package.json
+++ b/packages/cucumber/package.json
@@ -68,14 +68,15 @@
     "@letsrunit/playwright": "workspace:*",
     "@letsrunit/store": "workspace:*",
     "@letsrunit/utils": "workspace:*",
-    "@playwright/test": "1.58.2",
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
-    "@cucumber/cucumber": "^12.0.0"
+    "@cucumber/cucumber": "^12.0.0",
+    "@playwright/test": "^1.58.2"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^12.7.0"
+    "@cucumber/cucumber": "^12.7.0",
+    "@playwright/test": "1.58.2"
   },
   "module": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/init/src/setup/agents/codex.ts
+++ b/packages/init/src/setup/agents/codex.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AgentStrategy } from './types.js';
-import { ensureSkillDirectory, homePath } from './shared.js';
+import { ensureSkillDirectory } from './shared.js';
 
 const TOML_BLOCK = `[mcp_servers.letsrunit]\ncommand = "./node_modules/.bin/letsrunit-mcp"\n\n[mcp_servers.letsrunit.env]\nLETSRUNIT_MCP_RUNTIME_MODE = "project"\n`;
 
@@ -22,30 +22,12 @@ export function ensureCodexToml(path: string): 'created' | 'updated' | 'skipped'
   return 'updated';
 }
 
-export function projectInCodexConfig(path: string, cwd: string): boolean {
-  if (!existsSync(path)) return false;
-  const content = readFileSync(path, 'utf-8');
-  const escaped = cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`\\[projects\\."${escaped}"\\]`);
-  return pattern.test(content);
-}
-
 export const codexStrategy: AgentStrategy = {
   id: 'codex',
   label: 'Codex CLI',
-  detect: ({ cwd }) => {
-    const localConfig = join(cwd, '.codex', 'config.toml');
-    const homeConfig = homePath('.codex', 'config.toml');
-    if (projectInCodexConfig(homeConfig, cwd)) return true;
-    if (projectInCodexConfig(localConfig, cwd)) return true;
-    return false;
-  },
+  detect: ({ cwd }) => existsSync(join(cwd, '.codex', 'config.toml')),
   configureMcp: ({ cwd }) => {
     const localConfig = join(cwd, '.codex', 'config.toml');
-    const homeConfig = homePath('.codex', 'config.toml');
-    if (projectInCodexConfig(homeConfig, cwd) || !projectInCodexConfig(localConfig, cwd)) {
-      return ensureCodexToml(homeConfig);
-    }
     return ensureCodexToml(localConfig);
   },
   installSkill: ({ cwd }) => ensureSkillDirectory(cwd),

--- a/packages/init/tests/agents.test.ts
+++ b/packages/init/tests/agents.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { parseAgents, setupAgents } from '../src/setup/agents.js';
-import { ensureCodexToml, projectInCodexConfig } from '../src/setup/agents/codex.js';
+import { ensureCodexToml } from '../src/setup/agents/codex.js';
 import { ensureJsonMcpConfig, ensureSkillDirectory } from '../src/setup/agents/shared.js';
 
 const dirs: string[] = [];
@@ -76,16 +76,6 @@ describe('parseAgents', () => {
   });
 });
 
-describe('codex project detection', () => {
-  it('detects project in config toml', () => {
-    const dir = makeDir();
-    const path = join(dir, 'config.toml');
-    const cwd = '/tmp/example';
-    writeFileSync(path, `[projects."${cwd}"]\ntrust_level = "trusted"\n`, 'utf-8');
-    expect(projectInCodexConfig(path, cwd)).toBe(true);
-  });
-});
-
 describe('MCP config writers', () => {
   it('creates json mcp config', () => {
     const dir = makeDir();
@@ -125,7 +115,7 @@ describe('setupAgents behavior', () => {
     const cwd = makeDir();
     mockSkillDownload();
 
-    await setupAgents({ cwd, isInteractive: false }, { agents: ['cursor'] });
+    await setupAgents({ cwd, isInteractive: false }, { agents: ['cursor', 'codex'] });
 
     const configPath = join(cwd, '.cursor', 'mcp.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as {
@@ -139,6 +129,11 @@ describe('setupAgents behavior', () => {
     expect(readFileSync(join(cwd, '.agents', 'skills', 'letsrunit', 'docs', 'workflow.md'), 'utf-8')).toBe(
       'real workflow',
     );
+
+    const codexConfigPath = join(cwd, '.codex', 'config.toml');
+    const codexConfig = readFileSync(codexConfigPath, 'utf-8');
+    expect(codexConfig).toContain('command = "./node_modules/.bin/letsrunit-mcp"');
+    expect(codexConfig).toContain('LETSRUNIT_MCP_RUNTIME_MODE = "project"');
   });
 
   it('installs the full letsrunit skill directory from the agent repository', async () => {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -28,13 +28,10 @@ When a scenario passes, it produces a `.feature` file that gets committed and ru
 }
 ```
 
-**Codex CLI** — add to `~/.codex/config.toml`:
+**Codex CLI** — add the server:
 
-```toml
-[[mcp_servers]]
-name = "letsrunit"
-command = "npx"
-args = ["-y", "@letsrunit/mcp-server@latest"]
+```bash
+codex mcp add letsrunit -- npx -y @letsrunit/mcp-server@latest
 ```
 
 **Other agents** — standard MCP JSON config:

--- a/packages/mcp-server/src/bootstrap.ts
+++ b/packages/mcp-server/src/bootstrap.ts
@@ -3,7 +3,6 @@ import { loadLetsrunitEnv } from '@letsrunit/utils';
 import { realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 export type McpRuntimeMode = 'project' | 'standalone';
 
@@ -83,12 +82,12 @@ function runProjectLocalServer(projectEntrypointPath: string): never {
   process.exit(result.status ?? 1);
 }
 
-export function bootstrapProjectServer(): McpRuntimeMode {
+export function bootstrapProjectServer(currentEntrypointPath?: string | null): McpRuntimeMode {
   const projectRoot = resolveProjectRoot();
   loadLetsrunitEnv(projectRoot);
   const runtimeModeOverride = resolveRuntimeModeOverride();
 
-  const currentEntryPath = toRealpath(fileURLToPath(import.meta.url));
+  const currentEntryPath = toRealpath(currentEntrypointPath ?? process.argv[1] ?? null);
   const projectEntryPath = toRealpath(resolveFromProject('@letsrunit/mcp-server', projectRoot));
 
   const decision = decideHandoff(currentEntryPath, projectEntryPath, runtimeModeOverride);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,14 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { bootstrapProjectServer } from './bootstrap';
-
-declare const __LETSRUNIT_VERSION__: string | undefined;
-
-const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
-const runtimeMode = bootstrapProjectServer();
-
-const { SessionManager } = await import('./sessions');
-const {
+import { SessionManager } from './sessions';
+import {
   registerDebug,
   registerDiagnostics,
   registerDiff,
@@ -20,29 +14,38 @@ const {
   registerSessionClose,
   registerSessionStart,
   registerSnapshot,
-} = await import('./tools');
+} from './tools';
 
-const sessions = new SessionManager();
+declare const __LETSRUNIT_VERSION__: string | undefined;
 
-const server = new McpServer({
-  name: 'letsrunit',
-  version,
-  websiteUrl: 'https://letsrunit.ai',
-});
+const version = typeof __LETSRUNIT_VERSION__ === 'string' ? __LETSRUNIT_VERSION__ : 'unknown';
 
-registerSessionStart(server, sessions, { runtimeMode });
-registerRun(server, sessions);
-registerSnapshot(server, sessions);
-registerScreenshot(server, sessions);
-registerDebug(server, sessions);
-registerSessionClose(server, sessions);
-registerListSteps(server, sessions);
-registerListSessions(server, sessions);
-registerReload(server, { runtimeMode });
-registerDiff(server, sessions);
-if (process.env.LETSRUNIT_MCP_DIAGNOSTICS === 'enabled') {
-  registerDiagnostics(server, sessions);
+async function main(): Promise<void> {
+  const runtimeMode = bootstrapProjectServer(process.argv[1] ?? null);
+  const sessions = new SessionManager();
+
+  const server = new McpServer({
+    name: 'letsrunit',
+    version,
+    websiteUrl: 'https://letsrunit.ai',
+  });
+
+  registerSessionStart(server, sessions, { runtimeMode });
+  registerRun(server, sessions);
+  registerSnapshot(server, sessions);
+  registerScreenshot(server, sessions);
+  registerDebug(server, sessions);
+  registerSessionClose(server, sessions);
+  registerListSteps(server, sessions);
+  registerListSessions(server, sessions);
+  registerReload(server, { runtimeMode });
+  registerDiff(server, sessions);
+  if (process.env.LETSRUNIT_MCP_DIAGNOSTICS === 'enabled') {
+    registerDiagnostics(server, sessions);
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
 }
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+void main();

--- a/packages/mcp-server/src/utility/diagnostics.ts
+++ b/packages/mcp-server/src/utility/diagnostics.ts
@@ -3,7 +3,6 @@ import { registry } from '@letsrunit/bdd';
 import { realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { decideHandoff, resolveRuntimeModeOverride } from '../bootstrap';
 import {
   expandPathPatterns,
@@ -100,7 +99,7 @@ export async function collectDiagnostics(cwd?: string): Promise<Diagnostics> {
   const serverBddPath = toRealpath(resolveFrom('@letsrunit/bdd', import.meta.url));
   const projectBddPath = toRealpath(resolveFrom('@letsrunit/bdd', resolve(projectRoot, 'package.json')));
   const projectMcpEntryPath = resolveFrom('@letsrunit/mcp-server', resolve(projectRoot, 'package.json'));
-  const currentEntrypointPath = toRealpath(fileURLToPath(import.meta.url));
+  const currentEntrypointPath = toRealpath(process.argv[1] ?? null);
   const projectEntrypointPath = toRealpath(projectMcpEntryPath);
   const handoffDecision = decideHandoff(
     currentEntrypointPath,

--- a/packages/mcp-server/tests/bootstrap.test.ts
+++ b/packages/mcp-server/tests/bootstrap.test.ts
@@ -26,6 +26,15 @@ describe('decideHandoff', () => {
     expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'project' });
   });
 
+  it('uses project mode without handoff when current executable matches project entrypoint', () => {
+    const result = decideHandoff(
+      '/repo/packages/mcp-server/src/index.ts',
+      '/repo/packages/mcp-server/src/index.ts',
+      null,
+    );
+    expect(result).toEqual({ shouldHandoff: false, runtimeMode: 'project' });
+  });
+
   it('hands off to project-local server when available and different from current package', () => {
     const result = decideHandoff(
       '/npx-cache/@letsrunit/mcp-server/package.json',

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -43,7 +43,6 @@
   "packageManager": "yarn@4.10.3",
   "dependencies": {
     "@letsrunit/utils": "workspace:*",
-    "@playwright/test": "1.58.2",
     "case": "^1.6.3",
     "diff": "^8.0.3",
     "fast-json-stable-stringify": "^2.1.0",
@@ -54,7 +53,11 @@
     "unified": "^11.0.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.58.2",
     "@types/jsdom": "^27.0.0"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.58.2"
   },
   "module": "./src/index.ts",
   "types": "./src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,6 +4874,7 @@ __metadata:
     iso-639-1: "npm:^3.1.5"
   peerDependencies:
     "@cucumber/cucumber": ^12.0.0
+    "@playwright/test": ^1.58.2
   languageName: unknown
   linkType: soft
 
@@ -4980,6 +4981,8 @@ __metadata:
     jsdom: "npm:^27.4.0"
     typescript: "npm:^5.9.3"
     zod: "npm:^4.3.5"
+  peerDependencies:
+    "@playwright/test": ^1.58.2
   languageName: unknown
   linkType: soft
 
@@ -4998,6 +5001,7 @@ __metadata:
     uuid: "npm:^13.0.0"
   peerDependencies:
     "@cucumber/cucumber": ^12.0.0
+    "@playwright/test": ^1.58.2
   languageName: unknown
   linkType: soft
 
@@ -5103,6 +5107,8 @@ __metadata:
     rehype-parse: "npm:^9.0.1"
     rehype-stringify: "npm:^10.0.1"
     unified: "npm:^11.0.5"
+  peerDependencies:
+    "@playwright/test": ^1.58.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Type

Bug fix

## Summary

Fix MCP server setup and runtime handoff behavior, avoid duplicate Playwright installs, and repair the Dependabot automerge workflow.

## Changes

- fix MCP server handoff detection in `@letsrunit/mcp-server` bootstrap and diagnostics paths
- avoid duplicate Playwright installs across workspace package manifests
- keep Codex MCP setup project-local when generated by `npx letsrunit init`
- document global Codex setup via `codex mcp add letsrunit -- npx -y @letsrunit/mcp-server@latest`
- fix `.github/workflows/dependabot.yml` by moving `script` under `with` for `actions/github-script`

## Breaking changes

None.

## Validation

- `yarn test`
- `yarn test --project letsrunit packages/init/tests/agents.test.ts`
