### PR TITLE
fix: make langsmith tracing optional

### DIFF
--- a/docs/generating-tests.md
+++ b/docs/generating-tests.md
@@ -116,7 +116,7 @@ Log in with email and password, then verify the dashboard loads
 
 ### LangSmith tracing
 
-To inspect LLM calls made during `explore` or `generate`, enable LangSmith tracing:
+To inspect LLM calls made during `explore` or `generate`, install `langsmith@>=0.6.0` and enable LangSmith tracing:
 
 | Variable | Description |
 |----------|-------------|

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -10,6 +10,14 @@ npm install @letsrunit/ai
 yarn add @letsrunit/ai
 ```
 
+Install `langsmith` as well if you want LangSmith tracing:
+
+```bash
+npm install langsmith
+# or
+yarn add langsmith
+```
+
 Provides AI-driven capabilities for the `letsrunit` platform, leveraging the [AI SDK](https://sdk.vercel.ai/). It serves as a unified interface for generating text or structured objects using LLMs.
 
 ## Exported Functions
@@ -51,10 +59,13 @@ Translates text or JSON objects from English to a target language.
 
 ### LangSmith tracing (optional)
 
+LangSmith tracing is loaded lazily. If you configure any of the variables below, `langsmith@>=0.6.0` must also be installed.
+
 - `LANGSMITH_TRACING`
 - `LANGSMITH_WORKSPACE_ID`
 - `LANGSMITH_API_KEY`
 - `LANGSMITH_ENDPOINT`
+- `LANGSMITH_PROJECT`
 
 ## Testing
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -50,9 +50,16 @@
     "ai": "^5.0.121",
     "cache-manager": "^7.2.8",
     "iso-639-1": "^3.1.5",
-    "langsmith": "^0.4.7",
     "mustache": "^4.2.0",
     "zod": "^4.3.5"
+  },
+  "peerDependencies": {
+    "langsmith": ">=0.6.0"
+  },
+  "peerDependenciesMeta": {
+    "langsmith": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/mustache": "^4.2.6",

--- a/packages/ai/src/generate.ts
+++ b/packages/ai/src/generate.ts
@@ -1,22 +1,92 @@
 import * as ai from 'ai';
 import { ModelMessage, ToolSet } from 'ai';
-import { wrapAISDK } from 'langsmith/experimental/vercel';
 import Mustache from 'mustache';
 import * as z from 'zod';
 import { resolveModel } from './models';
 
 Mustache.escape = (text: string) => text;
 
-let { generateText, generateObject } = wrapAISDK(ai);
+const LANGSMITH_ENV_VARS = [
+  'LANGSMITH_TRACING',
+  'LANGSMITH_WORKSPACE_ID',
+  'LANGSMITH_API_KEY',
+  'LANGSMITH_ENDPOINT',
+  'LANGSMITH_PROJECT',
+] as const;
 
-export function mockAi(genText: typeof generateText, genObject?: typeof generateObject) {
-  generateText = genText;
-  if (genObject) generateObject = genObject;
+type GenerateText = typeof ai.generateText;
+type GenerateObject = typeof ai.generateObject;
+
+interface AISDK {
+  generateText: GenerateText;
+  generateObject: GenerateObject;
+}
+
+type LangSmithModule = typeof import('langsmith/experimental/vercel');
+
+let aiSdkOverride: AISDK | undefined;
+let aiSdkPromise: Promise<AISDK> | undefined;
+let langSmithLoader = importLangSmithModule;
+
+function defaultAISDK(): AISDK {
+  return {
+    generateText: ai.generateText,
+    generateObject: ai.generateObject,
+  };
+}
+
+function hasLangSmithConfiguration(): boolean {
+  return LANGSMITH_ENV_VARS.some((name) => isConfigured(process.env[name]));
+}
+
+function isConfigured(value: string | undefined): boolean {
+  if (!value) return false;
+  return value !== '0' && value.toLowerCase() !== 'false';
+}
+
+async function loadAISDK(): Promise<AISDK> {
+  if (aiSdkOverride) return aiSdkOverride;
+  if (!hasLangSmithConfiguration()) return defaultAISDK();
+  aiSdkPromise ??= loadLangSmithAISDK();
+  return aiSdkPromise;
+}
+
+async function loadLangSmithAISDK(): Promise<AISDK> {
+  try {
+    const { wrapAISDK } = await langSmithLoader();
+    return wrapAISDK(ai);
+  } catch (error) {
+    aiSdkPromise = undefined;
+    throw new Error(
+      'LangSmith tracing is configured, but `langsmith` is not installed. Install `langsmith@>=0.6.0` to enable tracing.',
+      { cause: error },
+    );
+  }
+}
+
+async function importLangSmithModule(): Promise<LangSmithModule> {
+  return import('langsmith/experimental/vercel');
+}
+
+export function mockAi(genText: GenerateText, genObject?: GenerateObject) {
+  aiSdkOverride = {
+    generateText: genText,
+    generateObject: genObject ?? ai.generateObject,
+  };
 
   return () => {
-    const wrapped = wrapAISDK(ai);
-    generateText = wrapped.generateText;
-    generateObject = wrapped.generateObject;
+    aiSdkOverride = undefined;
+    aiSdkPromise = undefined;
+  };
+}
+
+export function mockLangSmith(loader: typeof langSmithLoader) {
+  langSmithLoader = loader;
+  aiSdkPromise = undefined;
+
+  return () => {
+    langSmithLoader = importLangSmithModule;
+    aiSdkPromise = undefined;
   };
 }
 
@@ -33,6 +103,8 @@ export async function generate<T extends z.Schema | undefined = undefined>(
   prompt: string | ModelMessage[],
   opts: GenerateOptions<T> = {},
 ): Promise<T extends z.Schema ? z.infer<Exclude<T, undefined>> : string> {
+  const { generateText, generateObject } = await loadAISDK();
+
   if (opts.tools && opts.schema) {
     throw new Error("It's not possible to pass both a schema and tools");
   }

--- a/packages/ai/src/langsmith-optional.d.ts
+++ b/packages/ai/src/langsmith-optional.d.ts
@@ -1,0 +1,8 @@
+declare module 'langsmith/experimental/vercel' {
+  import type * as ai from 'ai';
+
+  export function wrapAISDK(sdk: typeof ai): {
+    generateText: typeof ai.generateText;
+    generateObject: typeof ai.generateObject;
+  };
+}

--- a/packages/ai/tests/generate.test.ts
+++ b/packages/ai/tests/generate.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import { generate, mockAi } from '../src/generate';
+import { generate, mockAi, mockLangSmith } from '../src/generate';
 import * as z from 'zod';
 
 const generateTextMock = vi.fn<any>();
 const generateObjectMock = vi.fn<any>();
 let restore: (() => void) | undefined;
+let restoreLangSmith: (() => void) | undefined;
 
 beforeEach(() => {
   generateTextMock.mockReset();
@@ -13,12 +14,18 @@ beforeEach(() => {
   delete process.env.LETSRUNIT_MODEL_LARGE;
   delete process.env.LETSRUNIT_MODEL_MEDIUM;
   delete process.env.LETSRUNIT_MODEL_SMALL;
+  delete process.env.LANGSMITH_TRACING;
+  delete process.env.LANGSMITH_WORKSPACE_ID;
+  delete process.env.LANGSMITH_API_KEY;
+  delete process.env.LANGSMITH_ENDPOINT;
+  delete process.env.LANGSMITH_PROJECT;
 
   restore = mockAi(generateTextMock as any, generateObjectMock as any);
 });
 
 afterEach(() => {
   restore?.();
+  restoreLangSmith?.();
 });
 
 describe('generate', () => {
@@ -107,6 +114,19 @@ describe('generate', () => {
     const schema = z.object({ a: z.string() });
     await expect(generate('system', 'prompt', { schema, tools: {} as any })).rejects.toThrow(
       "It's not possible to pass both a schema and tools",
+    );
+  });
+
+  it('throws a clear error when LangSmith is configured but not installed', async () => {
+    restore?.();
+    restore = undefined;
+    process.env.LANGSMITH_TRACING = 'true';
+    restoreLangSmith = mockLangSmith(async () => {
+      throw new Error('missing langsmith');
+    });
+
+    await expect(generate('system', 'prompt')).rejects.toThrow(
+      'LangSmith tracing is configured, but `langsmith` is not installed.',
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5050,10 +5050,14 @@ __metadata:
     ai: "npm:^5.0.121"
     cache-manager: "npm:^7.2.8"
     iso-639-1: "npm:^3.1.5"
-    langsmith: "npm:^0.4.7"
     mustache: "npm:^4.2.0"
     typescript: "npm:^5.9.3"
     zod: "npm:^4.3.5"
+  peerDependencies:
+    langsmith: ">=0.6.0"
+  peerDependenciesMeta:
+    langsmith:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -9317,13 +9321,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
-  languageName: node
-  linkType: hard
-
 "@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
@@ -11416,15 +11413,6 @@ __metadata:
   version: 3.4.2
   resolution: "consola@npm:3.4.2"
   checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
-  languageName: node
-  linkType: hard
-
-"console-table-printer@npm:^2.12.1":
-  version: 2.16.0
-  resolution: "console-table-printer@npm:2.16.0"
-  dependencies:
-    simple-wcswidth: "npm:^1.1.2"
-  checksum: 10c0/5f3ccb67531a79e5fab501f863ae9cca5525741428cb67ad5dd5ee55e56c0a1bce5d12930c7cf7e914af4f2a383303f19209863508f5f303387a5b12e6c4c75a
   languageName: node
   linkType: hard
 
@@ -15732,34 +15720,6 @@ __metadata:
   dependencies:
     seed-random: "npm:~2.2.0"
   checksum: 10c0/c8a3085fec79a3bac24bcccd0be7bf757f881e023d587ce858afc684c1a6c979ae6d9493e5efc6dc331527a8af0e4fe512d66e34ac39e79f45ae967ac8a60d6e
-  languageName: node
-  linkType: hard
-
-"langsmith@npm:^0.4.7":
-  version: 0.4.12
-  resolution: "langsmith@npm:0.4.12"
-  dependencies:
-    "@types/uuid": "npm:^10.0.0"
-    chalk: "npm:^4.1.2"
-    console-table-printer: "npm:^2.12.1"
-    p-queue: "npm:^6.6.2"
-    semver: "npm:^7.6.3"
-    uuid: "npm:^10.0.0"
-  peerDependencies:
-    "@opentelemetry/api": "*"
-    "@opentelemetry/exporter-trace-otlp-proto": "*"
-    "@opentelemetry/sdk-trace-base": "*"
-    openai: "*"
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    "@opentelemetry/exporter-trace-otlp-proto":
-      optional: true
-    "@opentelemetry/sdk-trace-base":
-      optional: true
-    openai:
-      optional: true
-  checksum: 10c0/92632e79842070d5b9588d95783e4f4a8baa012f89d61d4da82683f6c087b3e317c779c97f375c826952c98900ba09385615cfe6e9f728b647cdb954509440aa
   languageName: node
   linkType: hard
 
@@ -21216,7 +21176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.1":
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.1":
   version: 7.8.1
   resolution: "semver@npm:7.8.1"
   bin:
@@ -21479,13 +21439,6 @@ __metadata:
     "@sigstore/tuf": "npm:^4.0.2"
     "@sigstore/verify": "npm:^3.1.1"
   checksum: 10c0/8ebe0c2a7cb3cf9ed9fb775636ab2ae364cbdea9360ea256ab003d83b83dd5eeda8dd899cffcd3853fe711425c481fab2a74246772d75e3ecb9a9483f6700289
-  languageName: node
-  linkType: hard
-
-"simple-wcswidth@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "simple-wcswidth@npm:1.1.2"
-  checksum: 10c0/0db23ffef39d81a018a2354d64db1d08a44123c54263e48173992c61d808aaa8b58e5651d424e8c275589671f35e9094ac6fa2bbf2c98771b1bae9e007e611dd
   languageName: node
   linkType: hard
 
@@ -23087,15 +23040,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Type

Bug fix

## Summary

Makes LangSmith tracing optional in `@letsrunit/ai` so tracing is only enabled when configured, and throws a clear error when LangSmith env vars are set without the package being installed.

## Changes

- remove `langsmith` as a hard dependency of `@letsrunit/ai`
- lazy-load LangSmith tracing only when tracing env vars are configured
- throw an explicit runtime error if LangSmith is configured but not installed
- add focused tests for the optional tracing path and update the related docs
