### PR TITLE
[codex] add init and cucumber store config options

### DIFF
--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -49,11 +49,7 @@ const { failFast, worldParameters } = resolveDebugWorldParameters({
   },
 });
 
-const format = [
-  isAgentEnvironment(process.env)
-    ? '@letsrunit/cucumber/agent'
-    : '@letsrunit/cucumber/progress',
-];
+const format = [isAgentEnvironment(process.env) ? '@letsrunit/cucumber/agent' : '@letsrunit/cucumber/progress'];
 
 export default {
   format,
@@ -66,9 +62,7 @@ Pass extra env var keys for other agents:
 
 ```js
 const format = [
-  isAgentEnvironment(process.env, ['FOO_AGENT'])
-    ? '@letsrunit/cucumber/agent'
-    : '@letsrunit/cucumber/progress',
+  isAgentEnvironment(process.env, ['FOO_AGENT']) ? '@letsrunit/cucumber/agent' : '@letsrunit/cucumber/progress',
 ];
 ```
 
@@ -82,9 +76,10 @@ cucumber-js --fail-fast --world-parameters '{"headless":false}'
 
 A Cucumber plugin that listens to the message stream and writes structured run data to `.letsrunit/letsrunit.db` (via `@letsrunit/store`). It also saves all step attachments (screenshots, HTML) as content-addressed files under `.letsrunit/artifacts/`.
 
-`pluginOptions.letsrunitStore.directory` is the root letsrunit directory (for example `.letsrunit`), not the artifacts directory.
+`pluginOptions.letsrunitStore.directory` is the root letsrunit directory (for example `.letsrunit`), not the artifacts directory. `pluginOptions.letsrunitStore.enabled` defaults to `true`; set it to `false` to disable store recording for a run.
 
 Recorded data per run:
+
 - Session with the current git commit
 - Feature, scenario, and step records (deterministic UUIDs stable across re-runs)
 - Run status (`passed` / `failed`) with the failing step and error message
@@ -108,6 +103,7 @@ export default {
     pluginOptions: {
       letsrunitStore: {
         directory: '.letsrunit',
+        enabled: process.env.CI !== 'true',
       },
     },
     // ...
@@ -136,6 +132,7 @@ export default {
     pluginOptions: {
       letsrunitStore: {
         directory: '.letsrunit',
+        enabled: process.env.CI !== 'true',
       },
     },
   },

--- a/packages/cucumber/src/store.ts
+++ b/packages/cucumber/src/store.ts
@@ -25,7 +25,7 @@ import { existsSync, mkdirSync, statSync } from 'node:fs';
 import { utimes, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
-import { setConfiguredRunId, setConfiguredStoreDirectory } from './store-config';
+import { clearConfiguredStoreDirectory, setConfiguredRunId, setConfiguredStoreDirectory } from './store-config';
 
 const DEFAULT_DIR = '.letsrunit';
 
@@ -548,6 +548,7 @@ function startStoreRecorder({ on, directory }: { on: OnMessage; directory?: stri
 
 type StorePluginOptions = {
   directory?: string;
+  enabled?: boolean;
 };
 
 export default {
@@ -563,6 +564,11 @@ export default {
     operation: 'loadSources' | 'loadSupport' | 'runCucumber';
   }) {
     if (operation !== 'runCucumber') return;
+    if (options?.enabled === false) {
+      clearConfiguredStoreDirectory();
+      return;
+    }
+
     setConfiguredStoreDirectory(options?.directory);
     startStoreRecorder({ on, directory: options?.directory });
   },

--- a/packages/cucumber/tests/store.test.ts
+++ b/packages/cucumber/tests/store.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getConfiguredStoreDbPath, setConfiguredStoreDirectory } from '../src/store-config';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
@@ -56,5 +57,18 @@ describe('store plugin git metadata', () => {
     const db = openStore(join(directory, 'letsrunit.db'));
     const run = db.get('SELECT git_commit FROM runs LIMIT 1') as { git_commit: string | null } | undefined;
     expect(run?.git_commit).toBe('abc123');
+  });
+
+  it('skips recorder setup when disabled', () => {
+    setConfiguredStoreDirectory('stale-dir');
+
+    storePlugin.coordinator({
+      on: () => {},
+      operation: 'runCucumber',
+      options: { directory, enabled: false },
+    });
+
+    expect(execSync).not.toHaveBeenCalled();
+    expect(getConfiguredStoreDbPath()).toBeUndefined();
   });
 });

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -18,6 +18,8 @@ It can:
 
 - Install `@letsrunit/cli`
 - Configure letsrunit runtime settings in `.letsrunit/.env`, including `LETSRUNIT_BASE_URL` and mailbox settings
+- Add `.letsrunit` to `.gitignore`
+- Update `vite.config.ts` or `vite.config.js` to ignore `.letsrunit`
 - Configure CLI AI settings in `.letsrunit/.env` during interactive setup
 - Install `@letsrunit/mcp-server` (project-local MCP runtime)
 - Install `@cucumber/cucumber` when missing

--- a/packages/init/src/init.ts
+++ b/packages/init/src/init.ts
@@ -2,7 +2,7 @@ import { intro, log, outro } from '@clack/prompts';
 import { detectEnvironment } from './detect.js';
 import { formatInitHelp, shouldShowInitHelp, type InitOptions } from './init-options.js';
 import { detectAgentIds } from './setup/agents.js';
-import { detectAppTarget } from './setup/project-app.js';
+import { detectAppTarget, ensureLetsrunitIgnoredInVite } from './setup/project-app.js';
 import { ensureLetsrunitIgnored } from './setup/cli-ai.js';
 import { setupAgentIntegration } from './init/agents.js';
 import { setupBaseUrl } from './init/base-url.js';
@@ -55,6 +55,8 @@ export async function init(options: InitOptions = {}): Promise<void> {
 
   const ignoreResult = ensureLetsrunitIgnored(context.env.cwd);
   if (ignoreResult !== 'skipped') log.success(`.gitignore ${ignoreResult}`);
+  const viteIgnoreResult = ensureLetsrunitIgnoredInVite(context.env.cwd);
+  if (viteIgnoreResult === 'updated') log.success('vite config updated');
 
   await setupPlaywright(context);
   await setupBaseUrl(context);

--- a/packages/init/src/setup/cucumber.ts
+++ b/packages/init/src/setup/cucumber.ts
@@ -32,6 +32,7 @@ export default {
   pluginOptions: {
     letsrunitStore: {
       directory: '.letsrunit',
+      enabled: process.env.CI !== 'true',
     },
   },
   worldParameters,

--- a/packages/init/src/setup/project-app.ts
+++ b/packages/init/src/setup/project-app.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export type DetectionConfidence = 'high' | 'medium' | 'low';
@@ -29,11 +29,22 @@ interface FrameworkMatch {
 }
 
 const DEFAULT_PORT = 3000;
+const LETSRUNIT_VITE_IGNORE = '**/.letsrunit/**';
 
 const FRAMEWORK_RULES: Array<{ name: string; defaultPort: number; deps: string[]; scriptPatterns?: RegExp[] }> = [
   { name: 'nextjs', defaultPort: 3000, deps: ['next'], scriptPatterns: [/\bnext\s+(?:dev|start)\b/] },
-  { name: 'vite', defaultPort: 5173, deps: ['vite', '@vitejs/plugin-react', '@vitejs/plugin-vue'], scriptPatterns: [/\bvite\b/] },
-  { name: 'angular', defaultPort: 4200, deps: ['@angular/core', '@angular/cli'], scriptPatterns: [/\bng\s+(?:serve|dev)\b/] },
+  {
+    name: 'vite',
+    defaultPort: 5173,
+    deps: ['vite', '@vitejs/plugin-react', '@vitejs/plugin-vue'],
+    scriptPatterns: [/\bvite\b/],
+  },
+  {
+    name: 'angular',
+    defaultPort: 4200,
+    deps: ['@angular/core', '@angular/cli'],
+    scriptPatterns: [/\bng\s+(?:serve|dev)\b/],
+  },
   { name: 'nuxt', defaultPort: 3000, deps: ['nuxt'], scriptPatterns: [/\bnuxt\s+(?:dev|start)\b/] },
   { name: 'sveltekit', defaultPort: 5173, deps: ['@sveltejs/kit'] },
   { name: 'astro', defaultPort: 4321, deps: ['astro'], scriptPatterns: [/\bastro\s+dev\b/] },
@@ -49,6 +60,77 @@ function readText(path: string): string {
   } catch {
     return '';
   }
+}
+
+function insertIgnoredIntoArray(text: string): string | null {
+  const pattern = /ignored\s*:\s*\[([^\]]*)\]/;
+  if (!pattern.test(text)) return null;
+
+  return text.replace(pattern, (_match, content: string) => {
+    const trimmed = content.trim();
+    const prefix = trimmed ? `${trimmed}, ` : '';
+    return `ignored: [${prefix}'${LETSRUNIT_VITE_IGNORE}']`;
+  });
+}
+
+function insertIgnoredIntoWatch(text: string): string | null {
+  const pattern = /^([ \t]*)watch\s*:\s*\{/m;
+  if (!pattern.test(text)) return null;
+
+  return text.replace(pattern, `$1watch: {\n$1  ignored: ['${LETSRUNIT_VITE_IGNORE}'],`);
+}
+
+function insertWatchIntoServer(text: string): string | null {
+  const pattern = /^([ \t]*)server\s*:\s*\{/m;
+  if (!pattern.test(text)) return null;
+
+  return text.replace(pattern, `$1server: {\n$1  watch: {\n$1    ignored: ['${LETSRUNIT_VITE_IGNORE}'],\n$1  },`);
+}
+
+function insertServerIntoConfig(text: string): string | null {
+  const defineConfigPattern = /(defineConfig\s*\(\s*\{)(\s*\n)?/;
+  if (defineConfigPattern.test(text)) {
+    return text.replace(
+      defineConfigPattern,
+      `$1\n  server: {\n    watch: {\n      ignored: ['${LETSRUNIT_VITE_IGNORE}'],\n    },\n  },\n`,
+    );
+  }
+
+  const exportDefaultPattern = /(export\s+default\s+\{)(\s*\n)?/;
+  if (!exportDefaultPattern.test(text)) return null;
+
+  return text.replace(
+    exportDefaultPattern,
+    `$1\n  server: {\n    watch: {\n      ignored: ['${LETSRUNIT_VITE_IGNORE}'],\n    },\n  },\n`,
+  );
+}
+
+function selectViteConfig(cwd: string): string | null {
+  const tsPath = join(cwd, 'vite.config.ts');
+  if (existsSync(tsPath)) return tsPath;
+
+  const jsPath = join(cwd, 'vite.config.js');
+  if (existsSync(jsPath)) return jsPath;
+
+  return null;
+}
+
+export function ensureLetsrunitIgnoredInVite(cwd: string): 'updated' | 'skipped' | 'missing' {
+  const path = selectViteConfig(cwd);
+  if (!path) return 'missing';
+
+  const text = readText(path);
+  if (text.includes(LETSRUNIT_VITE_IGNORE)) return 'skipped';
+
+  const next =
+    insertIgnoredIntoArray(text) ??
+    insertIgnoredIntoWatch(text) ??
+    insertWatchIntoServer(text) ??
+    insertServerIntoConfig(text);
+  if (!next || next === text) return 'skipped';
+
+  writeFileSync(path, next, 'utf-8');
+  return 'updated';
 }
 
 function readPackageJson(cwd: string): PackageJson {
@@ -113,7 +195,14 @@ function extractPortByRegex(text: string, regex: RegExp): number | null {
 }
 
 function detectPortFromViteConfig(cwd: string): DetectionResult<number> | null {
-  const files = ['vite.config.ts', 'vite.config.js', 'vite.config.mts', 'vite.config.mjs', 'vite.config.cts', 'vite.config.cjs'];
+  const files = [
+    'vite.config.ts',
+    'vite.config.js',
+    'vite.config.mts',
+    'vite.config.mjs',
+    'vite.config.cts',
+    'vite.config.cjs',
+  ];
   for (const file of files) {
     const path = join(cwd, file);
     if (!existsSync(path)) continue;
@@ -139,7 +228,9 @@ function detectPortFromAngularConfig(cwd: string): DetectionResult<number> | nul
         projects?: Record<string, any>;
       };
       const projects = config.projects ?? {};
-      const names = [config.defaultProject, ...Object.keys(projects)].filter((v, i, a) => Boolean(v) && a.indexOf(v) === i) as string[];
+      const names = [config.defaultProject, ...Object.keys(projects)].filter(
+        (v, i, a) => Boolean(v) && a.indexOf(v) === i,
+      ) as string[];
 
       for (const name of names) {
         const project = projects[name] as any;
@@ -147,7 +238,11 @@ function detectPortFromAngularConfig(cwd: string): DetectionResult<number> | nul
         const serve = architect?.serve;
         const port = serve?.options?.port;
         if (Number.isFinite(port)) {
-          return { value: Number(port), confidence: 'high', evidence: [`${file}#projects.${name}.architect.serve.options.port`] };
+          return {
+            value: Number(port),
+            confidence: 'high',
+            evidence: [`${file}#projects.${name}.architect.serve.options.port`],
+          };
         }
 
         const configurations = serve?.configurations ?? {};

--- a/packages/init/tests/cucumber-setup.test.ts
+++ b/packages/init/tests/cucumber-setup.test.ts
@@ -26,6 +26,7 @@ describe('setupCucumber', () => {
     const config = readFileSync(join(cwd, 'cucumber.js'), 'utf-8');
     expect(config).toContain('loadLetsrunitEnv();');
     expect(config).toContain("baseURL: process.env.LETSRUNIT_BASE_URL ?? 'http://localhost:4100'");
+    expect(config).toContain("enabled: process.env.CI !== 'true'");
   });
 
   it('does not patch an existing cucumber.js', () => {

--- a/packages/init/tests/project-app.test.ts
+++ b/packages/init/tests/project-app.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { detectAppTarget } from '../src/setup/project-app.js';
+import { detectAppTarget, ensureLetsrunitIgnoredInVite } from '../src/setup/project-app.js';
 
 const dirs: string[] = [];
 
@@ -20,11 +20,7 @@ describe('detectAppTarget', () => {
   it('detects vite port from vite.config.ts', () => {
     const cwd = makeDir();
     writeFileSync(join(cwd, 'package.json'), JSON.stringify({ devDependencies: { vite: '^7.0.0' } }), 'utf-8');
-    writeFileSync(
-      join(cwd, 'vite.config.ts'),
-      "export default { server: { port: 6123 } };\n",
-      'utf-8',
-    );
+    writeFileSync(join(cwd, 'vite.config.ts'), 'export default { server: { port: 6123 } };\n', 'utf-8');
 
     const result = detectAppTarget(cwd);
     expect(result.value.framework).toBe('vite');
@@ -65,7 +61,11 @@ describe('detectAppTarget', () => {
   it('detects nuxt devServer port from nuxt.config.ts', () => {
     const cwd = makeDir();
     writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { nuxt: '^4.0.0' } }), 'utf-8');
-    writeFileSync(join(cwd, 'nuxt.config.ts'), "export default defineNuxtConfig({ devServer: { port: 3456 } });", 'utf-8');
+    writeFileSync(
+      join(cwd, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ devServer: { port: 3456 } });',
+      'utf-8',
+    );
 
     const result = detectAppTarget(cwd);
     expect(result.value.framework).toBe('nuxt');
@@ -75,7 +75,7 @@ describe('detectAppTarget', () => {
   it('detects astro port from astro.config.mjs', () => {
     const cwd = makeDir();
     writeFileSync(join(cwd, 'package.json'), JSON.stringify({ dependencies: { astro: '^5.0.0' } }), 'utf-8');
-    writeFileSync(join(cwd, 'astro.config.mjs'), "export default { server: { port: 4567 } };", 'utf-8');
+    writeFileSync(join(cwd, 'astro.config.mjs'), 'export default { server: { port: 4567 } };', 'utf-8');
 
     const result = detectAppTarget(cwd);
     expect(result.value.framework).toBe('astro');
@@ -104,5 +104,52 @@ describe('detectAppTarget', () => {
     const result = detectAppTarget(cwd);
     expect(result.value.framework).toBe('nextjs');
     expect(result.value.port).toBe(3000);
+  });
+});
+
+describe('ensureLetsrunitIgnoredInVite', () => {
+  it('updates vite.config.ts to ignore .letsrunit', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'vite.config.ts'),
+      ["import { defineConfig } from 'vite';", '', 'export default defineConfig({', '  plugins: [],', '});', ''].join(
+        '\n',
+      ),
+      'utf-8',
+    );
+
+    expect(ensureLetsrunitIgnoredInVite(cwd)).toBe('updated');
+    expect(readFileSync(join(cwd, 'vite.config.ts'), 'utf-8')).toContain("ignored: ['**/.letsrunit/**']");
+  });
+
+  it('falls back to vite.config.js when vite.config.ts does not exist', () => {
+    const cwd = makeDir();
+    writeFileSync(join(cwd, 'vite.config.js'), 'export default { server: { port: 6123 } };\n', 'utf-8');
+
+    expect(ensureLetsrunitIgnoredInVite(cwd)).toBe('updated');
+    expect(readFileSync(join(cwd, 'vite.config.js'), 'utf-8')).toContain("ignored: ['**/.letsrunit/**']");
+  });
+
+  it('adds letsrunit to an existing ignored array', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'vite.config.ts'),
+      "export default { server: { watch: { ignored: ['**/tmp/**'] } } };\n",
+      'utf-8',
+    );
+
+    expect(ensureLetsrunitIgnoredInVite(cwd)).toBe('updated');
+    expect(readFileSync(join(cwd, 'vite.config.ts'), 'utf-8')).toContain("ignored: ['**/tmp/**', '**/.letsrunit/**']");
+  });
+
+  it('skips when vite config already ignores .letsrunit', () => {
+    const cwd = makeDir();
+    writeFileSync(
+      join(cwd, 'vite.config.ts'),
+      "export default { server: { watch: { ignored: ['**/.letsrunit/**'] } } };\n",
+      'utf-8',
+    );
+
+    expect(ensureLetsrunitIgnoredInVite(cwd)).toBe('skipped');
   });
 });


### PR DESCRIPTION
## Type

Feature

## Summary

Improve generated letsrunit setup for local development and make the Cucumber store plugin configurable per run.

## Changes

- add `.letsrunit` to `.gitignore` during `init` and update `vite.config.ts` or `vite.config.js` to ignore `.letsrunit`
- scaffold `enabled: process.env.CI !== 'true'` into generated `cucumber.js` store plugin options
- add `letsrunitStore.enabled` to `@letsrunit/cucumber/store`, defaulting to enabled when omitted
- skip recorder setup cleanly when `letsrunitStore.enabled` is `false`
- add targeted tests and README updates for the new init and store plugin behavior

## Breaking changes

None.

## Validation

- `vitest run tests/project-app.test.ts tests/cli-ai.test.ts`
- `vitest run tests/store.test.ts`
- `vitest run tests/cucumber-setup.test.ts`
- `prettier --check src/setup/project-app.ts tests/project-app.test.ts src/init.ts README.md`
- `prettier --check src/store.ts tests/store.test.ts README.md`
- `prettier --check src/setup/cucumber.ts tests/cucumber-setup.test.ts`
