### PR TITLE
[codex] fix store SQLite lock contention

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -30,7 +30,7 @@ The store maintains seven tables:
 
 ### `openStore(path?)`
 
-Opens (or creates) the SQLite database at the given path. Defaults to `.letsrunit/letsrunit.db`. Enables WAL mode and foreign key enforcement, and runs the schema migration.
+Opens (or creates) the SQLite database at the given path. Defaults to `.letsrunit/letsrunit.db`. Enables SQLite busy-timeout handling, WAL mode, foreign key enforcement, and runs the schema migration with retry handling for transient lock contention.
 
 ```ts
 import { openStore } from '@letsrunit/store';

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -2,6 +2,9 @@ import nodeWasm from 'node-sqlite3-wasm';
 const { Database } = nodeWasm;
 export type Database = InstanceType<typeof nodeWasm.Database>;
 
+const BUSY_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS = [10, 25, 50, 100, 250] as const;
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS runs (
   id          BLOB PRIMARY KEY,
@@ -53,10 +56,35 @@ CREATE TABLE IF NOT EXISTS artifacts (
 );
 `;
 
+function isLockedError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('database is locked');
+}
+
+function sleepSync(delayMs: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+export function runWithRetry<T>(operation: () => T): T {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return operation();
+    } catch (error) {
+      if (!isLockedError(error) || attempt >= RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+
+      sleepSync(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+}
+
 export function openStore(path = '.letsrunit/letsrunit.db'): Database {
   const db = new Database(path);
-  db.run('PRAGMA journal_mode = WAL');
-  db.run('PRAGMA foreign_keys = ON');
-  db.exec(SCHEMA);
+  runWithRetry(() => {
+    db.run(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    db.run('PRAGMA journal_mode = WAL');
+    db.run('PRAGMA foreign_keys = ON');
+    db.exec(SCHEMA);
+  });
   return db;
 }

--- a/packages/store/src/write.ts
+++ b/packages/store/src/write.ts
@@ -1,9 +1,15 @@
-import type { Database } from './db';
+import { runWithRetry, type Database } from './db';
 
 import { toIdBlob } from './ids';
 
+function runStatement(db: Database, sql: string, params: Array<string | number | null | Uint8Array>): void {
+  runWithRetry(() => {
+    db.run(sql, params);
+  });
+}
+
 export function insertRun(db: Database, id: string, gitCommit: string | null, startedAt: number): void {
-  db.run('INSERT OR IGNORE INTO runs (id, started_at, git_commit) VALUES (?, ?, ?)', [
+  runStatement(db, 'INSERT OR IGNORE INTO runs (id, started_at, git_commit) VALUES (?, ?, ?)', [
     toIdBlob(id),
     startedAt,
     gitCommit,
@@ -11,7 +17,7 @@ export function insertRun(db: Database, id: string, gitCommit: string | null, st
 }
 
 export function upsertFeature(db: Database, id: string, path: string, name: string): void {
-  db.run('INSERT OR REPLACE INTO features (id, path, name) VALUES (?, ?, ?)', [toIdBlob(id), path, name]);
+  runStatement(db, 'INSERT OR REPLACE INTO features (id, path, name) VALUES (?, ?, ?)', [toIdBlob(id), path, name]);
 }
 
 interface ScenarioRefs {
@@ -29,7 +35,8 @@ export function upsertScenario(
   name: string,
   refs: ScenarioRefs = {},
 ): void {
-  db.run(
+  runStatement(
+    db,
     `INSERT OR REPLACE INTO scenarios (
       id, feature, "index", name, rule, outline, example_row, example_index
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -47,11 +54,11 @@ export function upsertScenario(
 }
 
 export function upsertStep(db: Database, id: string, text: string): void {
-  db.run('INSERT OR REPLACE INTO steps (id, text) VALUES (?, ?)', [toIdBlob(id), text]);
+  runStatement(db, 'INSERT OR REPLACE INTO steps (id, text) VALUES (?, ?)', [toIdBlob(id), text]);
 }
 
 export function upsertScenarioStep(db: Database, scenarioId: string, index: number, stepId: string): void {
-  db.run('INSERT OR REPLACE INTO scenario_steps (scenario, "index", step) VALUES (?, ?, ?)', [
+  runStatement(db, 'INSERT OR REPLACE INTO scenario_steps (scenario, "index", step) VALUES (?, ?, ?)', [
     toIdBlob(scenarioId),
     index,
     toIdBlob(stepId),
@@ -59,7 +66,7 @@ export function upsertScenarioStep(db: Database, scenarioId: string, index: numb
 }
 
 export function insertTest(db: Database, id: string, runId: string, scenarioId: string, startedAt: number): void {
-  db.run('INSERT INTO tests (id, run, scenario, started_at) VALUES (?, ?, ?, ?)', [
+  runStatement(db, 'INSERT INTO tests (id, run, scenario, started_at) VALUES (?, ?, ?, ?)', [
     toIdBlob(id),
     toIdBlob(runId),
     toIdBlob(scenarioId),
@@ -68,7 +75,7 @@ export function insertTest(db: Database, id: string, runId: string, scenarioId: 
 }
 
 export function finaliseTest(db: Database, id: string, status: string, failedStepIndex?: number, error?: string): void {
-  db.run('UPDATE tests SET status = ?, failed_step_index = ?, error = ? WHERE id = ?', [
+  runStatement(db, 'UPDATE tests SET status = ?, failed_step_index = ?, error = ? WHERE id = ?', [
     status,
     failedStepIndex ?? null,
     error ?? null,
@@ -77,7 +84,7 @@ export function finaliseTest(db: Database, id: string, status: string, failedSte
 }
 
 export function insertArtifact(db: Database, id: string, testId: string, stepIndex: number, filename: string): void {
-  db.run('INSERT INTO artifacts (id, test, step_index, filename) VALUES (?, ?, ?, ?)', [
+  runStatement(db, 'INSERT INTO artifacts (id, test, step_index, filename) VALUES (?, ?, ?, ?)', [
     toIdBlob(id),
     toIdBlob(testId),
     stepIndex,

--- a/packages/store/tests/retry.test.ts
+++ b/packages/store/tests/retry.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const run = vi.fn();
+const exec = vi.fn();
+const Database = vi.fn(function MockDatabase() {
+  return {
+  run,
+  exec,
+  };
+});
+
+vi.mock('node-sqlite3-wasm', () => ({
+  default: { Database },
+}));
+
+describe('store lock retries', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Database.mockClear();
+    run.mockReset();
+    exec.mockReset();
+  });
+
+  it('retries openStore setup when SQLite reports a transient lock', async () => {
+    const locked = new Error('SQLite3Error: database is locked');
+    run.mockImplementationOnce(() => {
+      throw locked;
+    });
+
+    const { openStore } = await import('../src/db.js');
+
+    expect(() => openStore('/tmp/letsrunit.db')).not.toThrow();
+    expect(Database).toHaveBeenCalledWith('/tmp/letsrunit.db');
+    expect(run).toHaveBeenCalledWith('PRAGMA busy_timeout = 5000');
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries write helpers when SQLite reports a transient lock', async () => {
+    const locked = new Error('SQLite3Error: database is locked');
+    const db = {
+      run: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw locked;
+        })
+        .mockImplementationOnce(() => undefined),
+    };
+
+    const { insertRun } = await import('../src/write.js');
+
+    expect(() => insertRun(db as never, '61'.repeat(32), 'abc123', 1000)).not.toThrow();
+    expect(db.run).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Type

Bug fix. Fixes #81

## Summary

Parallel `cucumber-js` processes could fail during `@letsrunit/cucumber/store` initialization because multiple processes tried to open and write to the shared SQLite store at the same time. This change keeps the single canonical database model intact while making startup and write operations tolerate transient lock contention.

## Changes

- add shared retry handling in `@letsrunit/store` for transient `database is locked` errors
- set `PRAGMA busy_timeout` during store open before WAL and schema setup
- route store write helpers through the retry wrapper so run, test, and artifact writes get the same protection
- document the new contention handling in the store README
- add focused retry tests for store open and write behavior

## Breaking changes

None.

## Validation

- `yarn test --project @letsrunit/store`
- `yarn test --project @letsrunit/cucumber tests/store.test.ts`
- reproduced the original failure against `../navara-cv` with three parallel `cucumber-js` runs on the unpatched package
- reran the same three scenarios against a patched bundle and all three passed without store init lock failures
