### PR TITLE
feat(cucumber): add stream plugin for remote ingestion

### DIFF
--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -12,7 +12,7 @@ yarn add @letsrunit/cucumber
 
 Cucumber CLI integration for letsrunit. It wires the `@letsrunit/bdd` step library into a Cucumber test suite and provides a plugin that persists run history and artifacts to the SQLite store.
 
-This package has four entry points.
+This package has five entry points.
 
 ## `@letsrunit/cucumber` — support file
 
@@ -84,6 +84,30 @@ Recorded data per run:
 - Feature, scenario, and step records (deterministic UUIDs stable across re-runs)
 - Run status (`passed` / `failed`) with the failing step and error message
 - All step artifacts linked to their step
+
+## `@letsrunit/cucumber/stream` — plugin
+
+A Cucumber plugin that emits the Cucumber message stream as ordered events for remote ingestion.
+
+- Always emits `feature_snapshot` first (v1)
+- Emits incremental events (`test_started`, `step_finished`, `attachment`, `test_finished`, `run_finished`)
+- Includes `runId`, `sessionId`, monotonic `seq`, and ISO timestamp per event
+- Uses no-op transport unless endpoint config is provided
+
+```js
+// cucumber.js
+export default {
+  default: {
+    plugin: ['@letsrunit/cucumber/stream'],
+    pluginOptions: {
+      letsrunitStream: {
+        endpoint: 'https://ingest.example.com/events',
+        token: process.env.LETSRUNIT_STREAM_TOKEN,
+      },
+    },
+  },
+};
+```
 
 ## `@letsrunit/cucumber/progress` — custom formatter
 

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -87,7 +87,7 @@ Recorded data per run:
 
 ## `@letsrunit/cucumber/stream` — plugin
 
-A Cucumber plugin that emits the Cucumber message stream as ordered events for remote ingestion.
+A Cucumber plugin that emits the Cucumber message stream as ordered events for remote ingestion over WebSocket.
 
 - Always emits `feature_snapshot` first (v1)
 - Emits incremental events (`test_started`, `step_finished`, `attachment`, `test_finished`, `run_finished`)
@@ -101,7 +101,7 @@ export default {
     plugin: ['@letsrunit/cucumber/stream'],
     pluginOptions: {
       letsrunitStream: {
-        endpoint: 'https://ingest.example.com/events',
+        endpoint: 'wss://ingest.example.com/events',
         token: process.env.LETSRUNIT_STREAM_TOKEN,
       },
     },

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -92,7 +92,7 @@ A Cucumber plugin that emits the Cucumber message stream as ordered events for r
 - Always emits `feature_snapshot` first (v1)
 - Emits incremental events (`test_started`, `step_finished`, `attachment`, `test_finished`, `run_finished`)
 - Includes `runId`, `sessionId`, monotonic `seq`, and ISO timestamp per event
-- Uses no-op transport unless endpoint config is provided
+- Stays inert unless endpoint config is provided (or a transport is injected in tests)
 
 ```js
 // cucumber.js

--- a/packages/cucumber/package.json
+++ b/packages/cucumber/package.json
@@ -35,6 +35,11 @@
         "import": "./dist/store.js",
         "default": "./dist/store.js"
       },
+      "./stream": {
+        "types": "./dist/stream.d.ts",
+        "import": "./dist/stream.js",
+        "default": "./dist/stream.js"
+      },
       "./progress": {
         "types": "./dist/progress.d.ts",
         "import": "./dist/progress.js",
@@ -90,6 +95,11 @@
       "types": "./src/store.ts",
       "import": "./src/store.ts",
       "default": "./src/store.ts"
+    },
+    "./stream": {
+      "types": "./src/stream.ts",
+      "import": "./src/stream.ts",
+      "default": "./src/stream.ts"
     },
     "./progress": {
       "types": "./src/progress.ts",

--- a/packages/cucumber/src/agent.ts
+++ b/packages/cucumber/src/agent.ts
@@ -1,12 +1,18 @@
 import { formatterHelpers, type IFormatterOptions, Formatter } from '@cucumber/cucumber';
-import { type Envelope, TestStepResultStatus } from '@cucumber/messages';
-import { computeScenarioId, computeStepId, normalizeSteps } from '@letsrunit/gherkin';
+import { type Envelope } from '@cucumber/messages';
 import { findArtifacts, findLastTest, openStore } from '@letsrunit/store';
 import { unifiedHtmlDiff } from '@letsrunit/playwright';
-import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  extractFailureDetails,
+  normalizeUrl,
+  stripAnsi,
+} from './lib/failure-details';
+import { resolveAllowedCommits } from './lib/git-commits';
+import { toScenarioId } from './lib/scenario-id';
+import { normalizeStatus, toDurationMs } from './lib/status';
 import { getConfiguredStoreDbPath } from './store-config';
 
 type ParsedStep = {
@@ -74,135 +80,13 @@ type ScenarioContext = {
   stepIndexById: Map<string, number>;
 };
 
-function normalizeStatus(status: string | number | undefined): string {
-  if (typeof status === 'string') return status.toLowerCase();
-  if (typeof status === 'number') {
-    const names = TestStepResultStatus as Record<number, string>;
-    const name = names[status];
-    if (typeof name === 'string') return name.toLowerCase();
-  }
-  return 'unknown';
-}
-
-function toDurationMs(duration?: { seconds?: number; nanos?: number }): number | undefined {
-  if (!duration) return undefined;
-  const seconds = duration.seconds ?? 0;
-  const nanos = duration.nanos ?? 0;
-  return seconds * 1000 + Math.floor(nanos / 1_000_000);
-}
-
-function toScenarioId(testSteps: ParsedStep[]): string | null {
-  const scenarioSteps = testSteps.filter((step) => step.text !== undefined);
-  if (scenarioSteps.length === 0) return null;
-
-  const normalized = normalizeSteps(
-    scenarioSteps.map((step) => ({
-      keyword: step.keyword,
-      text: step.text ?? '',
-      docString: step.argument?.docString,
-      dataTable: step.argument?.dataTable,
-    })),
-  );
-  return computeScenarioId(normalized.map((text) => computeStepId(text)));
-}
-
 function findAttachment(step: ParsedStep, mediaType: string): string | undefined {
   return step.attachments?.find((a) => a.mediaType === mediaType)?.body;
-}
-
-function normalizeUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/';
-  } catch {
-    return url.trim();
-  }
 }
 
 function extractUrlFromStep(step: ParsedStep): string | undefined {
   const urlRaw = findAttachment(step, 'text/x-letsrunit-url') ?? findAttachment(step, 'text/uri-list');
   if (urlRaw) return normalizeUrl(urlRaw);
-  return undefined;
-}
-
-function isStackLine(line: string): boolean {
-  return /^\s*at\s+/.test(line);
-}
-
-function stripAnsi(input: string): string {
-  // Regex from chalk/strip-ansi to remove ANSI escape sequences
-  const pattern =
-    /[\u001B\u009B][[\]()#;?]*(?:((?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
-  return input.replace(pattern, '');
-}
-
-function simplifyLocator(locator: string): string {
-  const raw = locator.trim();
-  const withoutMarker = raw.replace(/\s*\{fuzzy\}\s*$/i, '').trim();
-
-  const firstLocatorMatch = withoutMarker.match(/locator\((['"`])([\s\S]*?)\1\)/);
-  if (!firstLocatorMatch) return withoutMarker;
-  const simplified = firstLocatorMatch[2].trim();
-  return simplified || withoutMarker;
-}
-
-function extractLocatorRaw(lines: string[]): string | undefined {
-  const line = lines.find((l) => l.trim().startsWith('Locator:'));
-  if (!line) return undefined;
-  const raw = line.replace(/^\s*Locator:\s*/, '').trim();
-  return raw || undefined;
-}
-
-function extractLocator(lines: string[]): string | undefined {
-  const raw = extractLocatorRaw(lines);
-  if (!raw) return undefined;
-  return simplifyLocator(raw);
-}
-
-function extractExpected(lines: string[]): string | undefined {
-  const line = lines.find((l) => l.trim().startsWith('Expected:'));
-  if (!line) return undefined;
-  return line.replace(/^\s*Expected:\s*/, '').trim() || undefined;
-}
-
-function extractActual(lines: string[]): string | undefined {
-  const line = lines.find((l) => l.trim().startsWith('Received:'));
-  if (!line) return undefined;
-  return line.replace(/^\s*Received:\s*/, '').trim() || undefined;
-}
-
-function extractTimeout(lines: string[]): number | undefined {
-  const line = lines.find((l) => l.trim().startsWith('Timeout:'));
-  if (!line) return undefined;
-  const match = line.match(/(\d+)\s*ms/i);
-  if (!match) return undefined;
-  return Number(match[1]);
-}
-
-function extractErrorSummary(lines: string[]): string | undefined {
-  const callLogIdx = lines.findIndex((line) => line.trim().startsWith('Call log:'));
-  const stackIdx = lines.findIndex(isStackLine);
-  let cutOff = lines.length;
-  if (callLogIdx >= 0) cutOff = Math.min(cutOff, callLogIdx);
-  if (stackIdx >= 0) cutOff = Math.min(cutOff, stackIdx);
-
-  const candidates: string[] = [];
-  for (let i = 0; i < cutOff; i += 1) {
-    const match = lines[i].match(/^\s*Error:\s*(.+)\s*$/);
-    if (match) candidates.push(match[1].trim());
-  }
-  if (candidates.length > 0) return candidates[candidates.length - 1];
-
-  return lines
-    .map((line) => line.trim())
-    .find((line) => line.length > 0 && !isStackLine(line) && !line.startsWith('Call log:'));
-}
-
-function extractUrlFromMessage(lines: string[]): string | undefined {
-  for (const line of lines) {
-    const match = line.match(/\bURL:\s*(\S+)/i);
-    if (match) return match[1];
-  }
   return undefined;
 }
 
@@ -216,29 +100,20 @@ function classifyFailureKind(message: string, timeoutMs?: number): FailureStruct
 
 export function buildStructuredFailure(step: ParsedStep): FailureStructured {
   const raw = stripAnsi(step.result.message ?? '');
-  const lines = raw.split('\n');
-  const url = extractUrlFromStep(step) ?? extractUrlFromMessage(lines);
-  const timeout_ms = extractTimeout(lines);
+  const details = extractFailureDetails(raw);
+  const url = extractUrlFromStep(step) ?? details.url;
+  const timeout_ms = details.timeoutMs;
 
   return {
     kind: classifyFailureKind(raw, timeout_ms),
-    summary: extractErrorSummary(lines),
-    locator: extractLocator(lines),
-    locator_full: extractLocatorRaw(lines),
+    summary: details.error,
+    locator: details.locator,
+    locator_full: details.locatorFull,
     url,
-    expected: extractExpected(lines),
-    actual: extractActual(lines),
+    expected: details.expected,
+    actual: details.actual,
     timeout_ms,
   };
-}
-
-function resolveAllowedCommits(): string[] | undefined {
-  try {
-    const output = execSync('git log --format=%H', { encoding: 'utf8' });
-    return output.trim().split('\n').filter(Boolean);
-  } catch {
-    return undefined;
-  }
 }
 
 function emitLine(log: (buffer: string | Uint8Array) => void, payload: Record<string, unknown>): void {

--- a/packages/cucumber/src/lib/cucumber-state.ts
+++ b/packages/cucumber/src/lib/cucumber-state.ts
@@ -1,6 +1,11 @@
 import type { Envelope } from '@cucumber/messages';
-import { normalizeSteps } from '@letsrunit/gherkin';
-import { computeExampleRowId, computeOutlineId, computeScenarioId, computeStepId } from '@letsrunit/store';
+import {
+  computeExampleRowId,
+  computeOutlineId,
+  computeScenarioId,
+  computeStepId,
+  normalizeSteps,
+} from '@letsrunit/gherkin';
 
 export type AstStep = { keyword: string };
 

--- a/packages/cucumber/src/lib/cucumber-state.ts
+++ b/packages/cucumber/src/lib/cucumber-state.ts
@@ -1,0 +1,237 @@
+import type { Envelope } from '@cucumber/messages';
+import { normalizeSteps } from '@letsrunit/gherkin';
+import { computeExampleRowId, computeOutlineId, computeScenarioId, computeStepId } from '@letsrunit/store';
+
+export type AstStep = { keyword: string };
+
+export type ScenarioAstMeta = {
+  ruleKey?: string;
+  isOutline: boolean;
+  outlineStepIds?: string[];
+};
+
+export type ExampleRowMeta = {
+  values: string[];
+  index: number;
+};
+
+export type FeatureAstMeta = {
+  uri: string;
+  name: string;
+  scenarioByAstId: Map<string, ScenarioAstMeta>;
+  exampleRowByAstId: Map<string, ExampleRowMeta>;
+};
+
+export type PickleEntry = {
+  pickleId: string;
+  uri: string;
+  name: string;
+  scenarioId: string;
+  steps: { id: string; text: string }[];
+  ruleKey?: string;
+  outline?: string;
+  exampleRow?: string;
+  exampleIndex?: number;
+};
+
+export type TestCaseEntry = {
+  scenarioId: string;
+  stepIndexByTestStepId: Map<string, number>;
+};
+
+export type FailureInfo = {
+  failedStepIndex: number;
+  error: string | undefined;
+};
+
+interface GherkinScenarioNode {
+  id: string;
+  steps?: ReadonlyArray<{
+    id: string;
+    keyword: string;
+    text: string;
+    docString?: { content: string };
+    dataTable?: { rows: ReadonlyArray<{ cells: ReadonlyArray<{ value: string }> }> };
+  }>;
+  examples?: ReadonlyArray<{
+    tableBody?: ReadonlyArray<{ id: string; cells?: ReadonlyArray<{ value: string }> }>;
+  }>;
+}
+
+export type ParsedPickle = {
+  pickle: PickleEntry;
+  bucketKey: string;
+};
+
+export function normalizeScenarioTemplateStepIds(scenario: GherkinScenarioNode): string[] {
+  const normalized = normalizeSteps(
+    (scenario.steps ?? []).map((step) => ({
+      keyword: step.keyword,
+      text: step.text,
+      docString: step.docString,
+      dataTable: step.dataTable,
+    })),
+  );
+  return normalized.map((text) => computeStepId(text));
+}
+
+function normalizeRowValues(row?: { cells?: ReadonlyArray<{ value: string }> }): string[] {
+  if (!row?.cells?.length) return [];
+  return row.cells.map((cell) => cell.value.trim());
+}
+
+export function registerScenarioAst(
+  scenario: GherkinScenarioNode,
+  scenarioByAstId: Map<string, ScenarioAstMeta>,
+  exampleRowByAstId: Map<string, ExampleRowMeta>,
+  astStepMap: Map<string, AstStep>,
+  ruleKey?: string,
+): void {
+  const isOutline = (scenario.examples?.length ?? 0) > 0;
+  const outlineStepIds = isOutline ? normalizeScenarioTemplateStepIds(scenario) : undefined;
+
+  scenarioByAstId.set(scenario.id, {
+    ruleKey,
+    isOutline,
+    outlineStepIds,
+  });
+
+  for (const step of scenario.steps ?? []) {
+    astStepMap.set(step.id, { keyword: step.keyword.trim() });
+  }
+
+  let rowIndex = 0;
+  for (const examples of scenario.examples ?? []) {
+    for (const row of examples.tableBody ?? []) {
+      exampleRowByAstId.set(row.id, {
+        values: normalizeRowValues(row),
+        index: rowIndex++,
+      });
+    }
+  }
+}
+
+export function extractFeatureAst(envelope: Envelope, astStepMap: Map<string, AstStep>): FeatureAstMeta | undefined {
+  const doc = envelope.gherkinDocument;
+  if (!doc?.feature) return undefined;
+
+  const uri = doc.uri ?? '';
+  const feature = doc.feature;
+  const scenarioByAstId = new Map<string, ScenarioAstMeta>();
+  const exampleRowByAstId = new Map<string, ExampleRowMeta>();
+  let ruleIndex = 0;
+
+  for (const child of feature.children ?? []) {
+    if (child.background) {
+      for (const step of child.background.steps ?? []) {
+        astStepMap.set(step.id, { keyword: step.keyword.trim() });
+      }
+    }
+
+    if (child.scenario) {
+      registerScenarioAst(child.scenario, scenarioByAstId, exampleRowByAstId, astStepMap);
+    }
+
+    if (child.rule) {
+      const currentRuleIndex = ruleIndex++;
+      for (const ruleChild of child.rule.children ?? []) {
+        if (ruleChild.background) {
+          for (const step of ruleChild.background.steps ?? []) {
+            astStepMap.set(step.id, { keyword: step.keyword.trim() });
+          }
+        }
+
+        if (ruleChild.scenario) {
+          registerScenarioAst(
+            ruleChild.scenario,
+            scenarioByAstId,
+            exampleRowByAstId,
+            astStepMap,
+            `${uri}::${currentRuleIndex}`,
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    uri,
+    name: feature.name ?? '',
+    scenarioByAstId,
+    exampleRowByAstId,
+  };
+}
+
+export function parsePickle(
+  envelope: Envelope,
+  featureAstByUri: Map<string, FeatureAstMeta>,
+  astStepMap: Map<string, AstStep>,
+): ParsedPickle | undefined {
+  const pickle = envelope.pickle;
+  if (!pickle) return undefined;
+
+  const featureMeta = featureAstByUri.get(pickle.uri);
+
+  const normalizedPickleSteps = normalizeSteps(
+    pickle.steps.map((pickleStep) => ({
+      keyword: astStepMap.get(pickleStep.astNodeIds[0] ?? '')?.keyword ?? 'Given',
+      text: pickleStep.text,
+      docString: pickleStep.argument?.docString ? { content: pickleStep.argument.docString.content } : undefined,
+      dataTable: pickleStep.argument?.dataTable,
+    })),
+  );
+
+  const steps = normalizedPickleSteps.map((text) => ({ id: computeStepId(text), text }));
+  const scenarioId = computeScenarioId(steps.map((s) => s.id));
+  const scenarioAstId = pickle.astNodeIds.find((id) => featureMeta?.scenarioByAstId.has(id));
+  const scenarioMeta = scenarioAstId ? featureMeta?.scenarioByAstId.get(scenarioAstId) : undefined;
+
+  let outline: string | undefined;
+  let exampleRow: string | undefined;
+  let exampleIndex: number | undefined;
+
+  if (scenarioMeta?.isOutline) {
+    outline = computeOutlineId(scenarioMeta.outlineStepIds ?? []);
+    const rowAstId = pickle.astNodeIds.find((id) => featureMeta?.exampleRowByAstId.has(id));
+    const rowMeta = rowAstId ? featureMeta?.exampleRowByAstId.get(rowAstId) : undefined;
+
+    if (rowMeta) {
+      exampleIndex = rowMeta.index;
+      exampleRow = computeExampleRowId(rowMeta.values);
+    }
+  }
+
+  return {
+    bucketKey: pickle.uri,
+    pickle: {
+      pickleId: pickle.id,
+      uri: pickle.uri,
+      name: pickle.name,
+      scenarioId,
+      steps,
+      ruleKey: scenarioMeta?.ruleKey,
+      outline,
+      exampleRow,
+      exampleIndex,
+    },
+  };
+}
+
+export function parseTestCase(envelope: Envelope, pickleMap: Map<string, PickleEntry>): TestCaseEntry | undefined {
+  const testCase = envelope.testCase;
+  if (!testCase) return undefined;
+
+  const pickleEntry = pickleMap.get(testCase.pickleId);
+  if (!pickleEntry) return undefined;
+
+  const stepIndexByTestStepId = new Map<string, number>();
+  let pickleStepIndex = 0;
+
+  for (const testStep of testCase.testSteps) {
+    if (testStep.pickleStepId !== undefined && testStep.pickleStepId !== '') {
+      stepIndexByTestStepId.set(testStep.id, pickleStepIndex++);
+    }
+  }
+
+  return { scenarioId: pickleEntry.scenarioId, stepIndexByTestStepId };
+}

--- a/packages/cucumber/src/lib/failure-details.ts
+++ b/packages/cucumber/src/lib/failure-details.ts
@@ -1,0 +1,128 @@
+export type FailureDetails = {
+  error?: string;
+  locator?: string;
+  locatorFuzzy?: boolean;
+  locatorFull?: string;
+  url?: string;
+  expected?: string;
+  actual?: string;
+  timeoutMs?: number;
+};
+
+export function isStackLine(line: string): boolean {
+  return /^\s*at\s+/.test(line);
+}
+
+export function stripAnsi(input: string): string {
+  const pattern =
+    /[\u001B\u009B][[\]()#;?]*(?:((?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
+  return input.replace(pattern, '');
+}
+
+export function normalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/';
+  } catch {
+    return url.trim();
+  }
+}
+
+export function extractUrlFromMessage(lines: string[]): string | undefined {
+  for (const line of lines) {
+    const match = line.match(/\bURL:\s*(\S+)/i);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+export function extractPrimaryLocator(raw: string): string {
+  const withoutMarker = raw.replace(/\s*\{fuzzy\}\s*$/i, '').trim();
+  const firstLocatorMatch = withoutMarker.match(/locator\((['"`])([\s\S]*?)\1\)/);
+  if (!firstLocatorMatch) return withoutMarker;
+  return firstLocatorMatch[2].trim() || withoutMarker;
+}
+
+export function simplifyLocator(locator: string): { locator: string; fuzzy: boolean } {
+  const raw = locator.trim();
+  return {
+    locator: extractPrimaryLocator(raw),
+    fuzzy: raw.includes('{fuzzy}'),
+  };
+}
+
+export function extractLocatorRaw(lines: string[]): string | undefined {
+  const line = lines.find((l) => l.trim().startsWith('Locator:'));
+  if (!line) return undefined;
+  const raw = line.replace(/^\s*Locator:\s*/, '').trim();
+  return raw || undefined;
+}
+
+export function extractLocator(lines: string[]): string | undefined {
+  const raw = extractLocatorRaw(lines);
+  if (!raw) return undefined;
+  return simplifyLocator(raw).locator;
+}
+
+export function extractLocatorFuzzy(lines: string[]): boolean | undefined {
+  const raw = extractLocatorRaw(lines);
+  if (!raw) return undefined;
+  return simplifyLocator(raw).fuzzy;
+}
+
+export function extractExpected(lines: string[]): string | undefined {
+  const line = lines.find((l) => l.trim().startsWith('Expected:'));
+  if (!line) return undefined;
+  return line.replace(/^\s*Expected:\s*/, '').trim() || undefined;
+}
+
+export function extractActual(lines: string[]): string | undefined {
+  const line = lines.find((l) => l.trim().startsWith('Received:'));
+  if (!line) return undefined;
+  return line.replace(/^\s*Received:\s*/, '').trim() || undefined;
+}
+
+export function extractTimeoutMs(lines: string[]): number | undefined {
+  const line = lines.find((l) => l.trim().startsWith('Timeout:'));
+  if (!line) return undefined;
+  const match = line.match(/(\d+)\s*ms/i);
+  if (!match) return undefined;
+  return Number(match[1]);
+}
+
+export function extractErrorSummary(lines: string[]): string | undefined {
+  const callLogIdx = lines.findIndex((line) => line.trim().startsWith('Call log:'));
+  const stackIdx = lines.findIndex(isStackLine);
+  let cutOff = lines.length;
+  if (callLogIdx >= 0) cutOff = Math.min(cutOff, callLogIdx);
+  if (stackIdx >= 0) cutOff = Math.min(cutOff, stackIdx);
+
+  const candidates: string[] = [];
+  for (let i = 0; i < cutOff; i += 1) {
+    const match = lines[i].match(/^\s*Error:\s*(.+)\s*$/);
+    if (match) candidates.push(match[1].trim());
+  }
+
+  if (candidates.length > 0) return candidates[candidates.length - 1];
+
+  return lines
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !isStackLine(line) && !line.startsWith('Call log:'));
+}
+
+export function extractFailureDetails(message?: string): FailureDetails {
+  if (!message) return {};
+
+  const lines = stripAnsi(message).split('\n');
+
+  return {
+    error: extractErrorSummary(lines),
+    locator: extractLocator(lines),
+    locatorFuzzy: extractLocatorFuzzy(lines),
+    locatorFull: extractLocatorRaw(lines),
+    url: extractUrlFromMessage(lines),
+    expected: extractExpected(lines),
+    actual: extractActual(lines),
+    timeoutMs: extractTimeoutMs(lines),
+  };
+}

--- a/packages/cucumber/src/lib/git-commits.ts
+++ b/packages/cucumber/src/lib/git-commits.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'node:child_process';
+
+export function resolveAllowedCommits(): string[] | undefined {
+  try {
+    const output = execSync('git log --format=%H', { encoding: 'utf8' });
+    return output.trim().split('\n').filter(Boolean);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cucumber/src/lib/scenario-id.ts
+++ b/packages/cucumber/src/lib/scenario-id.ts
@@ -1,0 +1,27 @@
+import { normalizeSteps } from '@letsrunit/gherkin';
+import { computeScenarioId, computeStepId } from '@letsrunit/store';
+
+type ScenarioStep = {
+  keyword: string;
+  text?: string;
+  argument?: {
+    docString?: { content: string };
+    dataTable?: { rows: ReadonlyArray<{ cells: ReadonlyArray<{ value: string }> }> };
+  };
+};
+
+export function toScenarioId(testSteps: ScenarioStep[]): string | null {
+  const scenarioSteps = testSteps.filter((step) => step.text !== undefined);
+  if (scenarioSteps.length === 0) return null;
+
+  const normalized = normalizeSteps(
+    scenarioSteps.map((step) => ({
+      keyword: step.keyword,
+      text: step.text ?? '',
+      docString: step.argument?.docString,
+      dataTable: step.argument?.dataTable,
+    })),
+  );
+
+  return computeScenarioId(normalized.map((text) => computeStepId(text)));
+}

--- a/packages/cucumber/src/lib/scenario-id.ts
+++ b/packages/cucumber/src/lib/scenario-id.ts
@@ -1,5 +1,4 @@
-import { normalizeSteps } from '@letsrunit/gherkin';
-import { computeScenarioId, computeStepId } from '@letsrunit/store';
+import { computeScenarioId, computeStepId, normalizeSteps } from '@letsrunit/gherkin';
 
 type ScenarioStep = {
   keyword: string;

--- a/packages/cucumber/src/lib/status.ts
+++ b/packages/cucumber/src/lib/status.ts
@@ -1,0 +1,18 @@
+import { TestStepResultStatus } from '@cucumber/messages';
+
+export function normalizeStatus(status: string | number | undefined): string {
+  if (typeof status === 'string') return status.toLowerCase();
+  if (typeof status === 'number') {
+    const names = TestStepResultStatus as Record<number, string>;
+    const name = names[status];
+    if (typeof name === 'string') return name.toLowerCase();
+  }
+  return 'unknown';
+}
+
+export function toDurationMs(duration?: { seconds?: number; nanos?: number }): number | undefined {
+  if (!duration) return undefined;
+  const seconds = duration.seconds ?? 0;
+  const nanos = duration.nanos ?? 0;
+  return seconds * 1000 + Math.floor(nanos / 1_000_000);
+}

--- a/packages/cucumber/src/lib/stream-events.ts
+++ b/packages/cucumber/src/lib/stream-events.ts
@@ -1,0 +1,59 @@
+export type StreamEventType =
+  | 'feature_snapshot'
+  | 'test_started'
+  | 'step_finished'
+  | 'attachment'
+  | 'test_finished'
+  | 'run_finished';
+
+export type StreamEvent<TPayload = Record<string, unknown>> = {
+  runId: string;
+  sessionId: string;
+  seq: number;
+  ts: string;
+  type: StreamEventType;
+  payload: TPayload;
+};
+
+export type FeatureSnapshotPayload = {
+  feature: string;
+  uri: string;
+  name: string;
+};
+
+export type TestStartedPayload = {
+  testCaseStartedId: string;
+  testCaseId: string;
+  scenarioId?: string;
+  startedAt: number;
+};
+
+export type StepFinishedPayload = {
+  testCaseStartedId: string;
+  testStepId: string;
+  stepIndex?: number;
+  status?: number | string;
+  message?: string;
+  duration?: { seconds?: number; nanos?: number };
+};
+
+export type AttachmentPayload = {
+  testCaseStartedId?: string;
+  testStepId?: string;
+  stepIndex?: number;
+  mediaType: string;
+  contentEncoding: number | string;
+  body: string;
+};
+
+export type TestFinishedPayload = {
+  testCaseStartedId: string;
+  status: 'passed' | 'failed' | 'running';
+  failedStepIndex?: number;
+  error?: string;
+  willBeRetried?: boolean;
+};
+
+export type RunFinishedPayload = {
+  finishedAt: number;
+};

--- a/packages/cucumber/src/lib/transport.ts
+++ b/packages/cucumber/src/lib/transport.ts
@@ -12,55 +12,74 @@ export class NoopTransport implements StreamTransport {
   async close(): Promise<void> {}
 }
 
-export type HttpTransportOptions = {
+export type WebSocketTransportOptions = {
   endpoint: string;
   token?: string;
   headers?: Record<string, string>;
-  batchSize?: number;
 };
 
-export class HttpTransport implements StreamTransport {
+export class WebSocketTransport implements StreamTransport {
   private readonly endpoint: string;
   private readonly token?: string;
   private readonly headers: Record<string, string>;
-  private readonly batchSize: number;
-  private readonly queue: StreamEvent[] = [];
+  private socketPromise: Promise<WebSocket> | null = null;
 
-  constructor(options: HttpTransportOptions) {
+  constructor(options: WebSocketTransportOptions) {
     this.endpoint = options.endpoint;
     this.token = options.token;
     this.headers = options.headers ?? {};
-    this.batchSize = Math.max(1, options.batchSize ?? 20);
   }
 
   async send(events: StreamEvent[]): Promise<void> {
-    this.queue.push(...events);
-    if (this.queue.length >= this.batchSize) {
-      await this.flush();
-    }
+    const socket = await this.ensureSocket();
+    socket.send(JSON.stringify({ events }));
   }
 
-  async flush(): Promise<void> {
-    if (this.queue.length === 0) return;
-
-    const events = this.queue.splice(0, this.queue.length);
-
-    const response = await fetch(this.endpoint, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
-        ...this.headers,
-      },
-      body: JSON.stringify({ events }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Stream transport failed with status ${response.status}`);
-    }
-  }
+  async flush(): Promise<void> {}
 
   async close(): Promise<void> {
-    await this.flush();
+    if (!this.socketPromise) return;
+
+    const socket = await this.socketPromise;
+    if (socket.readyState === socket.OPEN || socket.readyState === socket.CONNECTING) {
+      socket.close();
+    }
+    this.socketPromise = null;
+  }
+
+  private async ensureSocket(): Promise<WebSocket> {
+    if (!this.socketPromise) {
+      this.socketPromise = this.openSocket();
+    }
+    return this.socketPromise;
+  }
+
+  private openSocket(): Promise<WebSocket> {
+    const WsCtor = globalThis.WebSocket;
+    if (!WsCtor) {
+      throw new Error('WebSocket is not available in this runtime');
+    }
+
+    return new Promise<WebSocket>((resolve, reject) => {
+      const protocols: string[] = [];
+      if (this.token) protocols.push(`bearer.${this.token}`);
+
+      const socket = new WsCtor(this.endpoint, protocols.length ? protocols : undefined);
+
+      socket.addEventListener('open', () => {
+        if (Object.keys(this.headers).length > 0) {
+          socket.send(JSON.stringify({ type: 'stream_headers', headers: this.headers }));
+        }
+        resolve(socket);
+      });
+
+      socket.addEventListener('error', () => {
+        reject(new Error('Failed to open WebSocket stream transport'));
+      });
+
+      socket.addEventListener('close', () => {
+        this.socketPromise = null;
+      });
+    });
   }
 }

--- a/packages/cucumber/src/lib/transport.ts
+++ b/packages/cucumber/src/lib/transport.ts
@@ -1,0 +1,66 @@
+import type { StreamEvent } from './stream-events';
+
+export interface StreamTransport {
+  send(events: StreamEvent[]): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export class NoopTransport implements StreamTransport {
+  async send(_events: StreamEvent[]): Promise<void> {}
+  async flush(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+export type HttpTransportOptions = {
+  endpoint: string;
+  token?: string;
+  headers?: Record<string, string>;
+  batchSize?: number;
+};
+
+export class HttpTransport implements StreamTransport {
+  private readonly endpoint: string;
+  private readonly token?: string;
+  private readonly headers: Record<string, string>;
+  private readonly batchSize: number;
+  private readonly queue: StreamEvent[] = [];
+
+  constructor(options: HttpTransportOptions) {
+    this.endpoint = options.endpoint;
+    this.token = options.token;
+    this.headers = options.headers ?? {};
+    this.batchSize = Math.max(1, options.batchSize ?? 20);
+  }
+
+  async send(events: StreamEvent[]): Promise<void> {
+    this.queue.push(...events);
+    if (this.queue.length >= this.batchSize) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.queue.length === 0) return;
+
+    const events = this.queue.splice(0, this.queue.length);
+
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+        ...this.headers,
+      },
+      body: JSON.stringify({ events }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Stream transport failed with status ${response.status}`);
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+  }
+}

--- a/packages/cucumber/src/lib/transport.ts
+++ b/packages/cucumber/src/lib/transport.ts
@@ -2,14 +2,7 @@ import type { StreamEvent } from './stream-events';
 
 export interface StreamTransport {
   send(events: StreamEvent[]): Promise<void>;
-  flush(): Promise<void>;
   close(): Promise<void>;
-}
-
-export class NoopTransport implements StreamTransport {
-  async send(_events: StreamEvent[]): Promise<void> {}
-  async flush(): Promise<void> {}
-  async close(): Promise<void> {}
 }
 
 export type WebSocketTransportOptions = {
@@ -34,8 +27,6 @@ export class WebSocketTransport implements StreamTransport {
     const socket = await this.ensureSocket();
     socket.send(JSON.stringify({ events }));
   }
-
-  async flush(): Promise<void> {}
 
   async close(): Promise<void> {
     if (!this.socketPromise) return;

--- a/packages/cucumber/src/progress.ts
+++ b/packages/cucumber/src/progress.ts
@@ -1,8 +1,12 @@
 import { formatterHelpers, type IFormatterOptions, ProgressFormatter as Base } from '@cucumber/cucumber';
-import { computeScenarioId, computeStepId, normalizeSteps } from '@letsrunit/gherkin';
 import { findLastPassingBaseline, openStore } from '@letsrunit/store';
-import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import {
+  extractFailureDetails as extractFailureDetailsFromMessage,
+  normalizeUrl,
+} from './lib/failure-details';
+import { resolveAllowedCommits } from './lib/git-commits';
+import { toScenarioId } from './lib/scenario-id';
 import { getConfiguredStoreDbPath } from './store-config';
 
 const STATUS_CHARACTER_MAPPING = new Map<string, string>([
@@ -44,30 +48,6 @@ function isFailureStatus(status: string): boolean {
   return status === 'FAILED' || status === 'AMBIGUOUS' || status === 'UNDEFINED';
 }
 
-function toScenarioId(testSteps: ParsedStep[]): string | null {
-  const scenarioSteps = testSteps.filter((step) => step.text !== undefined);
-  if (scenarioSteps.length === 0) return null;
-
-  const normalized = normalizeSteps(
-    scenarioSteps.map((step) => ({
-      keyword: step.keyword,
-      text: step.text ?? '',
-      docString: step.argument?.docString,
-      dataTable: step.argument?.dataTable,
-    })),
-  );
-  return computeScenarioId(normalized.map((text) => computeStepId(text)));
-}
-
-function resolveAllowedCommits(): string[] | undefined {
-  try {
-    const output = execSync('git log --format=%H', { encoding: 'utf8' });
-    return output.trim().split('\n').filter(Boolean);
-  } catch {
-    return undefined;
-  }
-}
-
 function shortCommit(commit: string): string {
   return commit.slice(0, 7);
 }
@@ -105,56 +85,6 @@ function resolveLastPassedLine({ scenarioId }: { scenarioId: string }): LastPass
   }
 }
 
-function extractPrimaryLocator(raw: string): string {
-  const withoutMarker = raw.replace(/\s*\{fuzzy\}\s*$/i, '').trim();
-
-  const firstLocatorMatch = withoutMarker.match(/locator\((['"`])([\s\S]*?)\1\)/);
-  if (!firstLocatorMatch) return withoutMarker;
-  return firstLocatorMatch[2].trim() || withoutMarker;
-}
-
-function simplifyLocator(locator: string): { locator: string; fuzzy: boolean } {
-  const raw = locator.trim();
-  const fuzzy = raw.includes('{fuzzy}');
-  return { locator: extractPrimaryLocator(raw), fuzzy };
-}
-
-function isStackLine(line: string): boolean {
-  return /^\s*at\s+/.test(line);
-}
-
-function extractLocator(lines: string[]): string | undefined {
-  const locatorLine = lines.find((line) => line.trim().startsWith('Locator:'));
-  if (!locatorLine) return undefined;
-  const raw = locatorLine.replace(/^\s*Locator:\s*/, '').trim();
-  return raw ? simplifyLocator(raw).locator : undefined;
-}
-
-function extractLocatorFuzzy(lines: string[]): boolean | undefined {
-  const locatorLine = lines.find((line) => line.trim().startsWith('Locator:'));
-  if (!locatorLine) return undefined;
-  const raw = locatorLine.replace(/^\s*Locator:\s*/, '').trim();
-  if (!raw) return undefined;
-  return simplifyLocator(raw).fuzzy;
-}
-
-function extractUrl(lines: string[]): string | undefined {
-  for (const line of lines) {
-    const match = line.match(/\bURL:\s*(\S+)/i);
-    if (match) return match[1];
-  }
-  return undefined;
-}
-
-function normalizeUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/';
-  } catch {
-    return url.trim();
-  }
-}
-
 function extractUrlFromAttachments(attachments?: Array<{ body: string; mediaType: string }>): string | undefined {
   if (!attachments || attachments.length === 0) return undefined;
 
@@ -168,34 +98,13 @@ function extractUrlFromAttachments(attachments?: Array<{ body: string; mediaType
   return undefined;
 }
 
-function extractError(lines: string[]): string | undefined {
-  const callLogIdx = lines.findIndex((line) => line.trim().startsWith('Call log:'));
-  const stackIdx = lines.findIndex(isStackLine);
-  let cutOff = lines.length;
-  if (callLogIdx >= 0) cutOff = Math.min(cutOff, callLogIdx);
-  if (stackIdx >= 0) cutOff = Math.min(cutOff, stackIdx);
-
-  const candidates: string[] = [];
-  for (let i = 0; i < cutOff; i += 1) {
-    const match = lines[i].match(/^\s*Error:\s*(.+)\s*$/);
-    if (match) candidates.push(match[1].trim());
-  }
-
-  if (candidates.length > 0) return candidates[candidates.length - 1];
-
-  return lines
-    .map((line) => line.trim())
-    .find((line) => line.length > 0 && !isStackLine(line) && !line.startsWith('Call log:'));
-}
-
 export function extractFailureDetails(message?: string): FailureDetails {
-  if (!message) return {};
-  const lines = message.split('\n');
+  const details = extractFailureDetailsFromMessage(message);
   return {
-    error: extractError(lines),
-    locator: extractLocator(lines),
-    locatorFuzzy: extractLocatorFuzzy(lines),
-    url: extractUrl(lines),
+    error: details.error,
+    locator: details.locator,
+    locatorFuzzy: details.locatorFuzzy,
+    url: details.url,
   };
 }
 

--- a/packages/cucumber/src/store.ts
+++ b/packages/cucumber/src/store.ts
@@ -1,8 +1,6 @@
 import { AttachmentContentEncoding, type Envelope, TestStepResultStatus } from '@cucumber/messages';
 import {
-  computeExampleRowId,
   computeFeatureId,
-  computeOutlineId,
   computeRuleId,
   computeScenarioId,
   computeStepId,
@@ -25,33 +23,21 @@ import { existsSync, mkdirSync, statSync } from 'node:fs';
 import { utimes, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  extractFeatureAst,
+  parsePickle,
+  parseTestCase,
+  type AstStep,
+  type FailureInfo,
+  type FeatureAstMeta,
+  type PickleEntry as ParsedPickleEntry,
+  type TestCaseEntry,
+} from './lib/cucumber-state';
 import { clearConfiguredStoreDirectory, setConfiguredRunId, setConfiguredStoreDirectory } from './store-config';
 
 const DEFAULT_DIR = '.letsrunit';
 
-type AstStep = {
-  keyword: string;
-};
-
-type ScenarioAstMeta = {
-  ruleKey?: string;
-  isOutline: boolean;
-  outlineStepIds?: string[];
-};
-
-type ExampleRowMeta = {
-  values: string[];
-  index: number;
-};
-
-type FeatureAstMeta = {
-  uri: string;
-  name: string;
-  scenarioByAstId: Map<string, ScenarioAstMeta>;
-  exampleRowByAstId: Map<string, ExampleRowMeta>;
-};
-
-type PickleEntry = {
+type PickleEntry = ParsedPickleEntry & {
   pickleId: string;
   uri: string;
   name: string;
@@ -71,35 +57,11 @@ type FeatureBucket = {
   pickles: PickleEntry[];
 };
 
-type TestCaseEntry = {
-  scenarioId: string;
-  stepIndexByTestStepId: Map<string, number>;
-};
-
 type TestEntry = {
   testId: string;
   scenarioId: string;
   stepIndexByTestStepId: Map<string, number>;
 };
-
-type FailureInfo = {
-  failedStepIndex: number;
-  error: string | undefined;
-};
-
-interface GherkinScenarioNode {
-  id: string;
-  steps?: ReadonlyArray<{
-    id: string;
-    keyword: string;
-    text: string;
-    docString?: { content: string };
-    dataTable?: { rows: ReadonlyArray<{ cells: ReadonlyArray<{ value: string }> }> };
-  }>;
-  examples?: ReadonlyArray<{
-    tableBody?: ReadonlyArray<{ id: string; cells?: ReadonlyArray<{ value: string }> }>;
-  }>;
-}
 
 type OnMessage = (key: 'message', handler: (value: Envelope) => void) => void;
 
@@ -143,18 +105,6 @@ async function hashBytes(bytes: Uint8Array): Promise<string> {
   const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
   const digest = await crypto.subtle.digest('SHA-256', buffer);
   return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-function normalizeScenarioTemplateStepIds(scenario: GherkinScenarioNode): string[] {
-  const normalized = normalizeSteps(
-    (scenario.steps ?? []).map((step) => ({
-      keyword: step.keyword,
-      text: step.text,
-      docString: step.docString,
-      dataTable: step.dataTable,
-    })),
-  );
-  return normalized.map((text) => computeStepId(text));
 }
 
 function getFeatureBucket(featureBuckets: Map<string, FeatureBucket>, uri: string, name: string): FeatureBucket {
@@ -210,42 +160,6 @@ function ensureFeaturePersisted(db: ReturnType<typeof openStore>, bucket: Featur
   bucket.persisted = true;
 }
 
-function normalizeRowValues(row?: { cells?: ReadonlyArray<{ value: string }> }): string[] {
-  if (!row?.cells?.length) return [];
-  return row.cells.map((cell) => cell.value.trim());
-}
-
-function registerScenarioAst(
-  scenario: GherkinScenarioNode,
-  scenarioByAstId: Map<string, ScenarioAstMeta>,
-  exampleRowByAstId: Map<string, ExampleRowMeta>,
-  astStepMap: Map<string, AstStep>,
-  ruleKey?: string,
-): void {
-  const isOutline = (scenario.examples?.length ?? 0) > 0;
-  const outlineStepIds = isOutline ? normalizeScenarioTemplateStepIds(scenario) : undefined;
-
-  scenarioByAstId.set(scenario.id, {
-    ruleKey,
-    isOutline,
-    outlineStepIds,
-  });
-
-  for (const step of scenario.steps ?? []) {
-    astStepMap.set(step.id, { keyword: step.keyword.trim() });
-  }
-
-  let rowIndex = 0;
-  for (const examples of scenario.examples ?? []) {
-    for (const row of examples.tableBody ?? []) {
-      exampleRowByAstId.set(row.id, {
-        values: normalizeRowValues(row),
-        index: rowIndex++,
-      });
-    }
-  }
-}
-
 function createRecorderContext(directory?: string): RecorderContext {
   const runDir = directory ?? DEFAULT_DIR;
   const artifactDir = join(runDir, 'artifacts');
@@ -281,112 +195,21 @@ function createRecorderContext(directory?: string): RecorderContext {
 }
 
 function handleGherkinDocument(envelope: Envelope, context: RecorderContext): boolean {
-  const doc = envelope.gherkinDocument;
-  if (!doc) return false;
+  const featureAst = extractFeatureAst(envelope, context.astStepMap);
+  if (!featureAst) return false;
 
-  const uri = doc.uri ?? '';
-  const feature = doc.feature;
-  if (!feature) return true;
-
-  const scenarioByAstId = new Map<string, ScenarioAstMeta>();
-  const exampleRowByAstId = new Map<string, ExampleRowMeta>();
-  let ruleIndex = 0;
-
-  for (const child of feature.children ?? []) {
-    if (child.background) {
-      for (const step of child.background.steps ?? []) {
-        context.astStepMap.set(step.id, { keyword: step.keyword.trim() });
-      }
-    }
-
-    if (child.scenario) {
-      registerScenarioAst(child.scenario, scenarioByAstId, exampleRowByAstId, context.astStepMap);
-    }
-
-    if (child.rule) {
-      const currentRuleIndex = ruleIndex++;
-
-      for (const ruleChild of child.rule.children ?? []) {
-        if (ruleChild.background) {
-          for (const step of ruleChild.background.steps ?? []) {
-            context.astStepMap.set(step.id, { keyword: step.keyword.trim() });
-          }
-        }
-
-        if (ruleChild.scenario) {
-          registerScenarioAst(
-            ruleChild.scenario,
-            scenarioByAstId,
-            exampleRowByAstId,
-            context.astStepMap,
-            `${uri}::${currentRuleIndex}`,
-          );
-        }
-      }
-    }
-  }
-
-  context.featureAstByUri.set(uri, {
-    uri,
-    name: feature.name ?? '',
-    scenarioByAstId,
-    exampleRowByAstId,
-  });
-
-  getFeatureBucket(context.featureBuckets, uri, feature.name ?? '');
+  context.featureAstByUri.set(featureAst.uri, featureAst);
+  getFeatureBucket(context.featureBuckets, featureAst.uri, featureAst.name);
   return true;
 }
 
 function handlePickle(envelope: Envelope, context: RecorderContext): boolean {
-  const pickle = envelope.pickle;
-  if (!pickle) return false;
+  const parsed = parsePickle(envelope, context.featureAstByUri, context.astStepMap);
+  if (!parsed) return false;
 
-  const featureMeta = context.featureAstByUri.get(pickle.uri);
-  const bucket = getFeatureBucket(context.featureBuckets, pickle.uri, featureMeta?.name ?? '');
-
-  const normalizedPickleSteps = normalizeSteps(
-    pickle.steps.map((pickleStep) => ({
-      keyword: context.astStepMap.get(pickleStep.astNodeIds[0] ?? '')?.keyword ?? 'Given',
-      text: pickleStep.text,
-      docString: pickleStep.argument?.docString ? { content: pickleStep.argument.docString.content } : undefined,
-      dataTable: pickleStep.argument?.dataTable,
-    })),
-  );
-
-  const steps = normalizedPickleSteps.map((text) => ({ id: computeStepId(text), text }));
-  const scenarioId = computeScenarioId(steps.map((s) => s.id));
-  const scenarioAstId = pickle.astNodeIds.find((id) => featureMeta?.scenarioByAstId.has(id));
-  const scenarioMeta = scenarioAstId ? featureMeta?.scenarioByAstId.get(scenarioAstId) : undefined;
-
-  let outline: string | undefined;
-  let exampleRow: string | undefined;
-  let exampleIndex: number | undefined;
-
-  if (scenarioMeta?.isOutline) {
-    outline = computeOutlineId(scenarioMeta.outlineStepIds ?? []);
-    const rowAstId = pickle.astNodeIds.find((id) => featureMeta?.exampleRowByAstId.has(id));
-    const rowMeta = rowAstId ? featureMeta?.exampleRowByAstId.get(rowAstId) : undefined;
-
-    if (rowMeta) {
-      exampleIndex = rowMeta.index;
-      exampleRow = computeExampleRowId(rowMeta.values);
-    }
-  }
-
-  const entry: PickleEntry = {
-    pickleId: pickle.id,
-    uri: pickle.uri,
-    name: pickle.name,
-    scenarioId,
-    steps,
-    ruleKey: scenarioMeta?.ruleKey,
-    outline,
-    exampleRow,
-    exampleIndex,
-  };
-
-  context.pickleMap.set(pickle.id, entry);
-  bucket.pickles.push(entry);
+  const bucket = getFeatureBucket(context.featureBuckets, parsed.pickle.uri, context.featureAstByUri.get(parsed.pickle.uri)?.name ?? '');
+  context.pickleMap.set(parsed.pickle.pickleId, parsed.pickle);
+  bucket.pickles.push(parsed.pickle);
   return true;
 }
 
@@ -402,18 +225,12 @@ function handleTestCase(envelope: Envelope, context: RecorderContext): boolean {
 
   ensureFeaturePersisted(context.db, bucket);
 
-  const stepIndexByTestStepId = new Map<string, number>();
-  let pickleStepIndex = 0;
-
-  for (const testStep of testCase.testSteps) {
-    if (testStep.pickleStepId !== undefined && testStep.pickleStepId !== '') {
-      stepIndexByTestStepId.set(testStep.id, pickleStepIndex++);
-    }
-  }
+  const parsed = parseTestCase(envelope, context.pickleMap);
+  if (!parsed) return true;
 
   context.testCaseMap.set(testCase.id, {
-    scenarioId: pickleEntry.scenarioId,
-    stepIndexByTestStepId,
+    scenarioId: parsed.scenarioId,
+    stepIndexByTestStepId: parsed.stepIndexByTestStepId,
   });
   return true;
 }

--- a/packages/cucumber/src/stream.ts
+++ b/packages/cucumber/src/stream.ts
@@ -2,7 +2,7 @@ import { AttachmentContentEncoding, type Envelope, TestStepResultStatus } from '
 import { v4 as uuidv4 } from 'uuid';
 import { extractFeatureAst, parsePickle, parseTestCase, type AstStep, type FailureInfo, type FeatureAstMeta, type PickleEntry, type TestCaseEntry } from './lib/cucumber-state';
 import type { AttachmentPayload, FeatureSnapshotPayload, StepFinishedPayload, StreamEvent, StreamEventType, TestFinishedPayload, TestStartedPayload } from './lib/stream-events';
-import { HttpTransport, NoopTransport, type StreamTransport } from './lib/transport';
+import { NoopTransport, type StreamTransport, WebSocketTransport } from './lib/transport';
 
 type OnMessage = (key: 'message', handler: (value: Envelope) => void) => void;
 
@@ -10,7 +10,6 @@ type StreamPluginOptions = {
   endpoint?: string;
   token?: string;
   sessionId?: string;
-  batchSize?: number;
   enabled?: boolean;
   transport?: StreamTransport;
 };
@@ -33,10 +32,9 @@ function resolveTransport(options?: StreamPluginOptions): StreamTransport {
   if (options?.enabled === false) return new NoopTransport();
   if (!options?.endpoint) return new NoopTransport();
 
-  return new HttpTransport({
+  return new WebSocketTransport({
     endpoint: options.endpoint,
     token: options.token,
-    batchSize: options.batchSize,
   });
 }
 

--- a/packages/cucumber/src/stream.ts
+++ b/packages/cucumber/src/stream.ts
@@ -2,7 +2,7 @@ import { AttachmentContentEncoding, type Envelope, TestStepResultStatus } from '
 import { v4 as uuidv4 } from 'uuid';
 import { extractFeatureAst, parsePickle, parseTestCase, type AstStep, type FailureInfo, type FeatureAstMeta, type PickleEntry, type TestCaseEntry } from './lib/cucumber-state';
 import type { AttachmentPayload, FeatureSnapshotPayload, StepFinishedPayload, StreamEvent, StreamEventType, TestFinishedPayload, TestStartedPayload } from './lib/stream-events';
-import { NoopTransport, type StreamTransport, WebSocketTransport } from './lib/transport';
+import { type StreamTransport, WebSocketTransport } from './lib/transport';
 
 type OnMessage = (key: 'message', handler: (value: Envelope) => void) => void;
 
@@ -29,13 +29,20 @@ type StreamContext = {
 
 function resolveTransport(options?: StreamPluginOptions): StreamTransport {
   if (options?.transport) return options.transport;
-  if (options?.enabled === false) return new NoopTransport();
-  if (!options?.endpoint) return new NoopTransport();
+  if (!options?.endpoint) {
+    throw new Error('Missing stream endpoint');
+  }
 
   return new WebSocketTransport({
     endpoint: options.endpoint,
     token: options.token,
   });
+}
+
+function shouldStart(options?: StreamPluginOptions): boolean {
+  if (options?.enabled === false) return false;
+  if (options?.transport) return true;
+  return typeof options?.endpoint === 'string' && options.endpoint.length > 0;
 }
 
 function statusFromFailure(failure?: FailureInfo, willBeRetried?: boolean): 'passed' | 'failed' | 'running' {
@@ -212,7 +219,6 @@ async function handleTestCaseFinished(envelope: Envelope, context: StreamContext
 async function handleRunFinished(envelope: Envelope, context: StreamContext): Promise<boolean> {
   if (!envelope.testRunFinished) return false;
   await emit(context, 'run_finished', { finishedAt: Date.now() });
-  await context.transport.flush();
   await context.transport.close();
   return true;
 }
@@ -253,6 +259,7 @@ export default {
   optionsKey: 'letsrunitStream' as const,
   coordinator({ on, options, operation }: { on: OnMessage; options?: StreamPluginOptions; operation: string }) {
     if (operation !== 'runCucumber') return;
+    if (!shouldStart(options)) return;
     startStreamRecorder({ on, options });
   },
 };

--- a/packages/cucumber/src/stream.ts
+++ b/packages/cucumber/src/stream.ts
@@ -1,7 +1,24 @@
 import { AttachmentContentEncoding, type Envelope, TestStepResultStatus } from '@cucumber/messages';
 import { v4 as uuidv4 } from 'uuid';
-import { extractFeatureAst, parsePickle, parseTestCase, type AstStep, type FailureInfo, type FeatureAstMeta, type PickleEntry, type TestCaseEntry } from './lib/cucumber-state';
-import type { AttachmentPayload, FeatureSnapshotPayload, StepFinishedPayload, StreamEvent, StreamEventType, TestFinishedPayload, TestStartedPayload } from './lib/stream-events';
+import {
+  extractFeatureAst,
+  parsePickle,
+  parseTestCase,
+  type AstStep,
+  type FailureInfo,
+  type FeatureAstMeta,
+  type PickleEntry,
+  type TestCaseEntry,
+} from './lib/cucumber-state';
+import type {
+  AttachmentPayload,
+  FeatureSnapshotPayload,
+  StepFinishedPayload,
+  StreamEvent,
+  StreamEventType,
+  TestFinishedPayload,
+  TestStartedPayload,
+} from './lib/stream-events';
 import { type StreamTransport, WebSocketTransport } from './lib/transport';
 
 type OnMessage = (key: 'message', handler: (value: Envelope) => void) => void;
@@ -23,6 +40,7 @@ type StreamContext = {
   featureAstByUri: Map<string, FeatureAstMeta>;
   pickleMap: Map<string, PickleEntry>;
   testCaseMap: Map<string, TestCaseEntry>;
+  startedTestCaseMap: Map<string, TestCaseEntry>;
   pendingFailures: Map<string, FailureInfo>;
   featureSent: boolean;
 };
@@ -130,6 +148,10 @@ async function handleTestCaseStarted(envelope: Envelope, context: StreamContext)
   if (!started) return false;
 
   const testCaseEntry = context.testCaseMap.get(started.testCaseId);
+  if (testCaseEntry) {
+    context.startedTestCaseMap.set(started.id, testCaseEntry);
+  }
+
   const payload: TestStartedPayload = {
     testCaseStartedId: started.id,
     testCaseId: started.testCaseId,
@@ -144,7 +166,7 @@ async function handleTestStepFinished(envelope: Envelope, context: StreamContext
   const finished = envelope.testStepFinished;
   if (!finished) return false;
 
-  const testCaseEntry = context.testCaseMap.get(finished.testCaseId);
+  const testCaseEntry = context.startedTestCaseMap.get(finished.testCaseStartedId);
   const stepIndex = testCaseEntry?.stepIndexByTestStepId.get(finished.testStepId);
   const payload: StepFinishedPayload = {
     testCaseStartedId: finished.testCaseStartedId,
@@ -180,9 +202,10 @@ async function handleAttachment(envelope: Envelope, context: StreamContext): Pro
 
   const testCaseStartedId = attachment.testCaseStartedId;
   const testStepId = attachment.testStepId;
-  const testCaseId = envelope.testCase?.id;
   const stepIndex =
-    testCaseId && testStepId ? context.testCaseMap.get(testCaseId)?.stepIndexByTestStepId.get(testStepId) : undefined;
+    testCaseStartedId && testStepId
+      ? context.startedTestCaseMap.get(testCaseStartedId)?.stepIndexByTestStepId.get(testStepId)
+      : undefined;
 
   const payload: AttachmentPayload = {
     testCaseStartedId,
@@ -201,6 +224,7 @@ async function handleTestCaseFinished(envelope: Envelope, context: StreamContext
   const finished = envelope.testCaseFinished;
   if (!finished) return false;
 
+  context.startedTestCaseMap.delete(finished.testCaseStartedId);
   const failure = context.pendingFailures.get(finished.testCaseStartedId);
   context.pendingFailures.delete(finished.testCaseStartedId);
 
@@ -245,12 +269,15 @@ function startStreamRecorder({ on, options }: { on: OnMessage; options?: StreamP
     featureAstByUri: new Map(),
     pickleMap: new Map(),
     testCaseMap: new Map(),
+    startedTestCaseMap: new Map(),
     pendingFailures: new Map(),
     featureSent: false,
   };
 
   on('message', (envelope: Envelope) => {
-    void handleEnvelope(envelope, context).catch(() => {});
+    void handleEnvelope(envelope, context).catch((error) => {
+      console.error('letsrunit stream plugin failed', error);
+    });
   });
 }
 

--- a/packages/cucumber/src/stream.ts
+++ b/packages/cucumber/src/stream.ts
@@ -1,0 +1,260 @@
+import { AttachmentContentEncoding, type Envelope, TestStepResultStatus } from '@cucumber/messages';
+import { v4 as uuidv4 } from 'uuid';
+import { extractFeatureAst, parsePickle, parseTestCase, type AstStep, type FailureInfo, type FeatureAstMeta, type PickleEntry, type TestCaseEntry } from './lib/cucumber-state';
+import type { AttachmentPayload, FeatureSnapshotPayload, StepFinishedPayload, StreamEvent, StreamEventType, TestFinishedPayload, TestStartedPayload } from './lib/stream-events';
+import { HttpTransport, NoopTransport, type StreamTransport } from './lib/transport';
+
+type OnMessage = (key: 'message', handler: (value: Envelope) => void) => void;
+
+type StreamPluginOptions = {
+  endpoint?: string;
+  token?: string;
+  sessionId?: string;
+  batchSize?: number;
+  enabled?: boolean;
+  transport?: StreamTransport;
+};
+
+type StreamContext = {
+  runId: string;
+  sessionId: string;
+  seq: number;
+  transport: StreamTransport;
+  astStepMap: Map<string, AstStep>;
+  featureAstByUri: Map<string, FeatureAstMeta>;
+  pickleMap: Map<string, PickleEntry>;
+  testCaseMap: Map<string, TestCaseEntry>;
+  pendingFailures: Map<string, FailureInfo>;
+  featureSent: boolean;
+};
+
+function resolveTransport(options?: StreamPluginOptions): StreamTransport {
+  if (options?.transport) return options.transport;
+  if (options?.enabled === false) return new NoopTransport();
+  if (!options?.endpoint) return new NoopTransport();
+
+  return new HttpTransport({
+    endpoint: options.endpoint,
+    token: options.token,
+    batchSize: options.batchSize,
+  });
+}
+
+function statusFromFailure(failure?: FailureInfo, willBeRetried?: boolean): 'passed' | 'failed' | 'running' {
+  if (willBeRetried) return 'running';
+  return failure ? 'failed' : 'passed';
+}
+
+function nextEvent<TPayload extends Record<string, unknown>>(
+  context: StreamContext,
+  type: StreamEventType,
+  payload: TPayload,
+): StreamEvent<TPayload> {
+  context.seq += 1;
+  return {
+    runId: context.runId,
+    sessionId: context.sessionId,
+    seq: context.seq,
+    ts: new Date().toISOString(),
+    type,
+    payload,
+  };
+}
+
+async function emit<TPayload extends Record<string, unknown>>(
+  context: StreamContext,
+  type: StreamEventType,
+  payload: TPayload,
+): Promise<void> {
+  await context.transport.send([nextEvent(context, type, payload)]);
+}
+
+async function handleSource(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  if (context.featureSent) return false;
+
+  const source = envelope.source;
+  if (!source?.data) return false;
+
+  const payload: FeatureSnapshotPayload = {
+    feature: source.data,
+    uri: source.uri ?? 'inline.feature',
+    name: '',
+  };
+  context.featureSent = true;
+  await emit(context, 'feature_snapshot', payload);
+  return true;
+}
+
+async function handleGherkinDocument(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  const featureAst = extractFeatureAst(envelope, context.astStepMap);
+  if (!featureAst) return false;
+
+  context.featureAstByUri.set(featureAst.uri, featureAst);
+
+  if (!context.featureSent) {
+    const payload: FeatureSnapshotPayload = {
+      feature: JSON.stringify(envelope.gherkinDocument),
+      uri: featureAst.uri,
+      name: featureAst.name,
+    };
+    context.featureSent = true;
+    await emit(context, 'feature_snapshot', payload);
+  }
+
+  return true;
+}
+
+function handlePickle(envelope: Envelope, context: StreamContext): boolean {
+  const parsed = parsePickle(envelope, context.featureAstByUri, context.astStepMap);
+  if (!parsed) return false;
+  context.pickleMap.set(parsed.pickle.pickleId, parsed.pickle);
+  return true;
+}
+
+function handleTestCase(envelope: Envelope, context: StreamContext): boolean {
+  const testCase = envelope.testCase;
+  if (!testCase) return false;
+  const parsed = parseTestCase(envelope, context.pickleMap);
+  if (!parsed) return true;
+  context.testCaseMap.set(testCase.id, parsed);
+  return true;
+}
+
+async function handleTestCaseStarted(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  const started = envelope.testCaseStarted;
+  if (!started) return false;
+
+  const testCaseEntry = context.testCaseMap.get(started.testCaseId);
+  const payload: TestStartedPayload = {
+    testCaseStartedId: started.id,
+    testCaseId: started.testCaseId,
+    scenarioId: testCaseEntry?.scenarioId,
+    startedAt: Date.now(),
+  };
+  await emit(context, 'test_started', payload);
+  return true;
+}
+
+async function handleTestStepFinished(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  const finished = envelope.testStepFinished;
+  if (!finished) return false;
+
+  const testCaseEntry = context.testCaseMap.get(finished.testCaseId);
+  const stepIndex = testCaseEntry?.stepIndexByTestStepId.get(finished.testStepId);
+  const payload: StepFinishedPayload = {
+    testCaseStartedId: finished.testCaseStartedId,
+    testStepId: finished.testStepId,
+    stepIndex,
+    status: finished.testStepResult.status,
+    message: finished.testStepResult.message,
+    duration: finished.testStepResult.duration,
+  };
+  await emit(context, 'step_finished', payload);
+
+  const status = finished.testStepResult.status;
+  const isFailing =
+    status === TestStepResultStatus.FAILED ||
+    status === TestStepResultStatus.AMBIGUOUS ||
+    status === TestStepResultStatus.UNDEFINED;
+
+  if (isFailing && !context.pendingFailures.has(finished.testCaseStartedId)) {
+    context.pendingFailures.set(finished.testCaseStartedId, {
+      failedStepIndex: stepIndex ?? -1,
+      error: finished.testStepResult.message,
+    });
+  }
+
+  return true;
+}
+
+async function handleAttachment(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  const attachment = envelope.attachment;
+  if (!attachment) return false;
+
+  if (attachment.mediaType === 'text/x-letsrunit-url') return true;
+
+  const testCaseStartedId = attachment.testCaseStartedId;
+  const testStepId = attachment.testStepId;
+  const testCaseId = envelope.testCase?.id;
+  const stepIndex =
+    testCaseId && testStepId ? context.testCaseMap.get(testCaseId)?.stepIndexByTestStepId.get(testStepId) : undefined;
+
+  const payload: AttachmentPayload = {
+    testCaseStartedId,
+    testStepId,
+    stepIndex,
+    mediaType: attachment.mediaType,
+    contentEncoding: attachment.contentEncoding ?? AttachmentContentEncoding.IDENTITY,
+    body: attachment.body,
+  };
+
+  await emit(context, 'attachment', payload);
+  return true;
+}
+
+async function handleTestCaseFinished(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  const finished = envelope.testCaseFinished;
+  if (!finished) return false;
+
+  const failure = context.pendingFailures.get(finished.testCaseStartedId);
+  context.pendingFailures.delete(finished.testCaseStartedId);
+
+  const payload: TestFinishedPayload = {
+    testCaseStartedId: finished.testCaseStartedId,
+    status: statusFromFailure(failure, finished.willBeRetried),
+    failedStepIndex: failure?.failedStepIndex,
+    error: failure?.error,
+    willBeRetried: finished.willBeRetried,
+  };
+
+  await emit(context, 'test_finished', payload);
+  return true;
+}
+
+async function handleRunFinished(envelope: Envelope, context: StreamContext): Promise<boolean> {
+  if (!envelope.testRunFinished) return false;
+  await emit(context, 'run_finished', { finishedAt: Date.now() });
+  await context.transport.flush();
+  await context.transport.close();
+  return true;
+}
+
+async function handleEnvelope(envelope: Envelope, context: StreamContext): Promise<void> {
+  await handleSource(envelope, context);
+  await handleGherkinDocument(envelope, context);
+  handlePickle(envelope, context);
+  handleTestCase(envelope, context);
+  await handleTestCaseStarted(envelope, context);
+  await handleTestStepFinished(envelope, context);
+  await handleAttachment(envelope, context);
+  await handleTestCaseFinished(envelope, context);
+  await handleRunFinished(envelope, context);
+}
+
+function startStreamRecorder({ on, options }: { on: OnMessage; options?: StreamPluginOptions }): void {
+  const context: StreamContext = {
+    runId: uuidv4(),
+    sessionId: options?.sessionId ?? uuidv4(),
+    seq: 0,
+    transport: resolveTransport(options),
+    astStepMap: new Map(),
+    featureAstByUri: new Map(),
+    pickleMap: new Map(),
+    testCaseMap: new Map(),
+    pendingFailures: new Map(),
+    featureSent: false,
+  };
+
+  on('message', (envelope: Envelope) => {
+    void handleEnvelope(envelope, context).catch(() => {});
+  });
+}
+
+export default {
+  type: 'plugin' as const,
+  optionsKey: 'letsrunitStream' as const,
+  coordinator({ on, options, operation }: { on: OnMessage; options?: StreamPluginOptions; operation: string }) {
+    if (operation !== 'runCucumber') return;
+    startStreamRecorder({ on, options });
+  },
+};

--- a/packages/cucumber/tests/stream/stream.test.ts
+++ b/packages/cucumber/tests/stream/stream.test.ts
@@ -34,6 +34,20 @@ describe('stream plugin', () => {
     });
   });
 
+  it('stays inert when no endpoint or transport is configured', () => {
+    let unconfiguredHandler: ((value: Envelope) => void) | undefined;
+
+    streamPlugin.coordinator({
+      operation: 'runCucumber',
+      options: undefined,
+      on: (_key, handler) => {
+        unconfiguredHandler = handler;
+      },
+    });
+
+    expect(unconfiguredHandler).toBeUndefined();
+  });
+
   it('emits feature snapshot first and monotonically increasing seq', async () => {
     onMessage?.({ source: { data: 'Feature: Login\n  Scenario: ok\n    Given I log in', uri: 'features/login.feature' } } as Envelope);
     onMessage?.({ testRunFinished: { success: true } } as Envelope);
@@ -119,5 +133,8 @@ describe('stream plugin', () => {
 
     const seq = transport.events.map((e) => e.seq);
     expect(seq).toEqual([...seq].sort((a, b) => a - b));
+
+    expect(transport.events[2].payload).toMatchObject({ stepIndex: 0 });
+    expect(transport.events[3].payload).toMatchObject({ stepIndex: 0 });
   });
 });

--- a/packages/cucumber/tests/stream/stream.test.ts
+++ b/packages/cucumber/tests/stream/stream.test.ts
@@ -11,7 +11,6 @@ class CaptureTransport implements StreamTransport {
     this.events.push(...events);
   }
 
-  async flush(): Promise<void> {}
   async close(): Promise<void> {}
 }
 

--- a/packages/cucumber/tests/stream/stream.test.ts
+++ b/packages/cucumber/tests/stream/stream.test.ts
@@ -1,0 +1,124 @@
+import type { Envelope } from '@cucumber/messages';
+import { beforeEach, describe, expect, it } from 'vitest';
+import streamPlugin from '../../src/stream';
+import type { StreamEvent } from '../../src/lib/stream-events';
+import type { StreamTransport } from '../../src/lib/transport';
+
+class CaptureTransport implements StreamTransport {
+  readonly events: StreamEvent[] = [];
+
+  async send(events: StreamEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+
+  async flush(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+describe('stream plugin', () => {
+  let onMessage: ((value: Envelope) => void) | undefined;
+  let transport: CaptureTransport;
+
+  beforeEach(() => {
+    transport = new CaptureTransport();
+    onMessage = undefined;
+
+    streamPlugin.coordinator({
+      operation: 'runCucumber',
+      options: {
+        sessionId: 'sess-1',
+        transport,
+      },
+      on: (_key, handler) => {
+        onMessage = handler;
+      },
+    });
+  });
+
+  it('emits feature snapshot first and monotonically increasing seq', async () => {
+    onMessage?.({ source: { data: 'Feature: Login\n  Scenario: ok\n    Given I log in', uri: 'features/login.feature' } } as Envelope);
+    onMessage?.({ testRunFinished: { success: true } } as Envelope);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(transport.events[0].type).toBe('feature_snapshot');
+    expect(transport.events[0].seq).toBe(1);
+    expect(transport.events[1].type).toBe('run_finished');
+    expect(transport.events[1].seq).toBe(2);
+  });
+
+  it('emits started/step/attachment/finished flow', async () => {
+    onMessage?.({ source: { data: 'Feature: Login\n  Scenario: ok\n    Given I log in', uri: 'features/login.feature' } } as Envelope);
+
+    onMessage?.({
+      gherkinDocument: {
+        uri: 'features/login.feature',
+        feature: {
+          name: 'Login',
+          children: [
+            {
+              scenario: {
+                id: 'ast-s1',
+                steps: [{ id: 'ast-st1', keyword: 'Given ', text: 'I log in' }],
+              },
+            },
+          ],
+        },
+      },
+    } as Envelope);
+
+    onMessage?.({
+      pickle: {
+        id: 'pickle-1',
+        uri: 'features/login.feature',
+        name: 'ok',
+        astNodeIds: ['ast-s1'],
+        steps: [{ text: 'I log in', astNodeIds: ['ast-st1'] }],
+      },
+    } as Envelope);
+
+    onMessage?.({
+      testCase: {
+        id: 'tc-1',
+        pickleId: 'pickle-1',
+        testSteps: [{ id: 'ts-1', pickleStepId: 'ps-1' }],
+      },
+    } as Envelope);
+
+    onMessage?.({ testCaseStarted: { id: 'tcs-1', testCaseId: 'tc-1' } } as Envelope);
+
+    onMessage?.({
+      testStepFinished: {
+        testCaseStartedId: 'tcs-1',
+        testCaseId: 'tc-1',
+        testStepId: 'ts-1',
+        testStepResult: { status: 1, message: '' },
+      },
+    } as Envelope);
+
+    onMessage?.({
+      attachment: {
+        testCaseStartedId: 'tcs-1',
+        testStepId: 'ts-1',
+        mediaType: 'text/plain',
+        contentEncoding: 0,
+        body: 'hello',
+      },
+    } as Envelope);
+
+    onMessage?.({ testCaseFinished: { testCaseStartedId: 'tcs-1', willBeRetried: false } } as Envelope);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(transport.events.map((e) => e.type)).toEqual([
+      'feature_snapshot',
+      'test_started',
+      'step_finished',
+      'attachment',
+      'test_finished',
+    ]);
+
+    const seq = transport.events.map((e) => e.seq);
+    expect(seq).toEqual([...seq].sort((a, b) => a - b));
+  });
+});

--- a/packages/cucumber/tsup.config.ts
+++ b/packages/cucumber/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/store.ts', 'src/progress.ts', 'src/agent.ts', 'src/config.ts'],
+  entry: ['src/index.ts', 'src/store.ts', 'src/stream.ts', 'src/progress.ts', 'src/agent.ts', 'src/config.ts'],
   format: ['esm'],
   platform: 'node',
   dts: true,


### PR DESCRIPTION
## Type

Feature

## Summary

Add a Cucumber stream plugin that emits ordered run events over WebSocket for remote ingestion, and harden the client-side event state handling so the package is merge-ready.

## Changes
- add `@letsrunit/cucumber/stream` as a new plugin entrypoint
- emit ordered stream events for feature snapshots, test lifecycle, attachments, and run completion
- add WebSocket transport support and shared stream event types
- refactor shared cucumber parsing/status helpers used by stream, agent, progress, and store paths
- fix stream state handling so `step_finished` and `attachment` resolve `stepIndex` correctly
- make stream startup inert when unconfigured and align the README with that behavior
- add package tests covering stream startup, event ordering, monotonic `seq`, and attachment step indexing

## Breaking changes

None.
